### PR TITLE
Introduce token_context utility

### DIFF
--- a/mpi4jax/__init__.py
+++ b/mpi4jax/__init__.py
@@ -18,6 +18,7 @@ from ._src import (  # noqa: E402
     scatter,
     send,
     sendrecv,
+    token_context,
 )
 
 __all__ = [
@@ -32,10 +33,11 @@ __all__ = [
     "scatter",
     "send",
     "sendrecv",
+    "token_context",
 ]
 
 # TODO: remove in next minor release
-from ._deprecations import (  # noqa: E402
+from ._deprecations import (  # noqa: E402, F401
     Allreduce,
     Bcast,
     Recv,
@@ -45,10 +47,10 @@ from ._deprecations import (  # noqa: E402
 
 __all__.extend(
     [
-        Allreduce,
-        Bcast,
-        Recv,
-        Send,
-        Sendrecv,
+        "Allreduce",
+        "Bcast",
+        "Recv",
+        "Send",
+        "Sendrecv",
     ]
 )

--- a/mpi4jax/_src/__init__.py
+++ b/mpi4jax/_src/__init__.py
@@ -5,6 +5,7 @@ from mpi4py import MPI  # noqa: F401
 # this registers our custom XLA functions
 from . import xla_bridge  # noqa: F401
 
+# import public API
 from .collective_ops.allgather import allgather  # noqa: F401
 from .collective_ops.allreduce import allreduce  # noqa: F401
 from .collective_ops.alltoall import alltoall  # noqa: F401
@@ -16,6 +17,8 @@ from .collective_ops.scan import scan  # noqa: F401
 from .collective_ops.scatter import scatter  # noqa: F401
 from .collective_ops.send import send  # noqa: F401
 from .collective_ops.sendrecv import sendrecv  # noqa: F401
+
+from .token_context import token_context  # noqa: F401
 
 # check version of jaxlib
 import jaxlib

--- a/mpi4jax/_src/collective_ops/allgather.py
+++ b/mpi4jax/_src/collective_ops/allgather.py
@@ -19,6 +19,7 @@ from ..utils import (
 )
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
+from ..token_context import inject_ctx_token
 from ..comm import get_default_comm
 
 # The Jax primitive
@@ -31,8 +32,10 @@ mpi_allgather_impl = default_primitive_impl(mpi_allgather_p)
     comm=(type(None), _MPI.Intracomm, HashableMPIType),
     token=(type(None), xla.Token, core.Tracer),
 )
+@inject_ctx_token
 def allgather(
     x,
+    *,
     comm=None,
     token=None,
 ):
@@ -63,10 +66,12 @@ def allgather(
 
     comm = wrap_as_hashable(comm)
 
-    return mpi_allgather_p.bind(
-        x,
-        token,
-        comm=comm,
+    return tuple(
+        mpi_allgather_p.bind(
+            x,
+            token,
+            comm=comm,
+        )
     )
 
 

--- a/mpi4jax/_src/collective_ops/allreduce.py
+++ b/mpi4jax/_src/collective_ops/allreduce.py
@@ -19,6 +19,7 @@ from ..utils import (
 )
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
+from ..token_context import inject_ctx_token
 from ..comm import get_default_comm
 
 # The Jax primitive
@@ -32,7 +33,8 @@ mpi_allreduce_impl = default_primitive_impl(mpi_allreduce_p)
     comm=(type(None), _MPI.Intracomm, HashableMPIType),
     token=(type(None), xla.Token, core.Tracer),
 )
-def allreduce(x, op, comm=None, token=None):
+@inject_ctx_token
+def allreduce(x, op, *, comm=None, token=None):
     """Perform an allreduce operation.
 
     .. note::
@@ -62,7 +64,7 @@ def allreduce(x, op, comm=None, token=None):
 
     op = wrap_as_hashable(op)
     comm = wrap_as_hashable(comm)
-    return mpi_allreduce_p.bind(x, token, op=op, comm=comm, transpose=False)
+    return tuple(mpi_allreduce_p.bind(x, token, op=op, comm=comm, transpose=False))
 
 
 # This function compiles the operation

--- a/mpi4jax/_src/collective_ops/alltoall.py
+++ b/mpi4jax/_src/collective_ops/alltoall.py
@@ -19,6 +19,7 @@ from ..utils import (
 )
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
+from ..token_context import inject_ctx_token
 from ..comm import get_default_comm
 
 
@@ -32,8 +33,10 @@ mpi_alltoall_impl = default_primitive_impl(mpi_alltoall_p)
     comm=(type(None), _MPI.Intracomm, HashableMPIType),
     token=(type(None), xla.Token, core.Tracer),
 )
+@inject_ctx_token
 def alltoall(
     x,
+    *,
     comm=None,
     token=None,
 ):
@@ -64,10 +67,12 @@ def alltoall(
 
     comm = wrap_as_hashable(comm)
 
-    return mpi_alltoall_p.bind(
-        x,
-        token,
-        comm=comm,
+    return tuple(
+        mpi_alltoall_p.bind(
+            x,
+            token,
+            comm=comm,
+        )
     )
 
 

--- a/mpi4jax/_src/collective_ops/bcast.py
+++ b/mpi4jax/_src/collective_ops/bcast.py
@@ -19,6 +19,7 @@ from ..utils import (
 )
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
+from ..token_context import inject_ctx_token
 from ..comm import get_default_comm
 
 # The Jax primitive
@@ -32,7 +33,8 @@ mpi_bcast_impl = default_primitive_impl(mpi_bcast_p)
     comm=(type(None), _MPI.Intracomm, HashableMPIType),
     token=(type(None), xla.Token, core.Tracer),
 )
-def bcast(x, root, comm=None, token=None):
+@inject_ctx_token
+def bcast(x, root, *, comm=None, token=None):
     """Perform a bcast (broadcast) operation.
 
     .. warning::
@@ -66,9 +68,9 @@ def bcast(x, root, comm=None, token=None):
     res, token = mpi_bcast_p.bind(x, token, root=root, comm=comm)
 
     if rank == root:
-        return x, token
+        return (x, token)
 
-    return res, token
+    return (res, token)
 
 
 # This function compiles the operation

--- a/mpi4jax/_src/collective_ops/gather.py
+++ b/mpi4jax/_src/collective_ops/gather.py
@@ -19,6 +19,7 @@ from ..utils import (
 )
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
+from ..token_context import inject_ctx_token
 from ..comm import get_default_comm
 
 # The Jax primitive
@@ -32,9 +33,11 @@ mpi_gather_impl = default_primitive_impl(mpi_gather_p)
     comm=(type(None), _MPI.Intracomm, HashableMPIType),
     token=(type(None), xla.Token, core.Tracer),
 )
+@inject_ctx_token
 def gather(
     x,
     root,
+    *,
     comm=None,
     token=None,
 ):
@@ -80,9 +83,9 @@ def gather(
     )
 
     if rank != root:
-        return x, token
+        return (x, token)
 
-    return res, token
+    return (res, token)
 
 
 # This function compiles the operation

--- a/mpi4jax/_src/collective_ops/recv.py
+++ b/mpi4jax/_src/collective_ops/recv.py
@@ -20,6 +20,7 @@ from ..utils import (
 )
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
+from ..token_context import inject_ctx_token
 from ..comm import get_default_comm
 
 # The Jax primitive
@@ -35,8 +36,10 @@ mpi_recv_impl = default_primitive_impl(mpi_recv_p)
     status=(type(None), _MPI.Status, HashableMPIType),
     token=(type(None), xla.Token, core.Tracer),
 )
+@inject_ctx_token
 def recv(
     x,
+    *,
     source=_MPI.ANY_SOURCE,
     tag=_MPI.ANY_TAG,
     comm=None,
@@ -77,7 +80,9 @@ def recv(
     if status is not None:
         status = wrap_as_hashable(status)
 
-    return mpi_recv_p.bind(x, token, source=source, tag=tag, comm=comm, status=status)
+    return tuple(
+        mpi_recv_p.bind(x, token, source=source, tag=tag, comm=comm, status=status)
+    )
 
 
 # This function compiles the operation

--- a/mpi4jax/_src/collective_ops/recv.py
+++ b/mpi4jax/_src/collective_ops/recv.py
@@ -39,8 +39,8 @@ mpi_recv_impl = default_primitive_impl(mpi_recv_p)
 @inject_ctx_token
 def recv(
     x,
-    *,
     source=_MPI.ANY_SOURCE,
+    *,
     tag=_MPI.ANY_TAG,
     comm=None,
     status=None,

--- a/mpi4jax/_src/collective_ops/reduce.py
+++ b/mpi4jax/_src/collective_ops/reduce.py
@@ -19,6 +19,7 @@ from ..utils import (
 )
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
+from ..token_context import inject_ctx_token
 from ..comm import get_default_comm
 
 # The Jax primitive
@@ -33,7 +34,8 @@ mpi_reduce_impl = default_primitive_impl(mpi_reduce_p)
     comm=(type(None), _MPI.Intracomm, HashableMPIType),
     token=(type(None), xla.Token, core.Tracer),
 )
-def reduce(x, op, root, comm=None, token=None):
+@inject_ctx_token
+def reduce(x, op, root, *, comm=None, token=None):
     """Perform a reduce operation.
 
     Arguments:
@@ -65,9 +67,9 @@ def reduce(x, op, root, comm=None, token=None):
     res, token = mpi_reduce_p.bind(x, token, op=op, root=root, comm=comm)
 
     if rank != root:
-        return x, token
+        return (x, token)
 
-    return res, token
+    return (res, token)
 
 
 # This function compiles the operation

--- a/mpi4jax/_src/collective_ops/scan.py
+++ b/mpi4jax/_src/collective_ops/scan.py
@@ -19,6 +19,7 @@ from ..utils import (
 )
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
+from ..token_context import inject_ctx_token
 from ..comm import get_default_comm
 
 # The Jax primitive
@@ -32,7 +33,8 @@ mpi_scan_impl = default_primitive_impl(mpi_scan_p)
     comm=(type(None), _MPI.Intracomm, HashableMPIType),
     token=(type(None), xla.Token, core.Tracer),
 )
-def scan(x, op, comm=None, token=None):
+@inject_ctx_token
+def scan(x, op, *, comm=None, token=None):
     """Perform a scan operation.
 
     Arguments:
@@ -57,7 +59,7 @@ def scan(x, op, comm=None, token=None):
 
     op = wrap_as_hashable(op)
     comm = wrap_as_hashable(comm)
-    return mpi_scan_p.bind(x, token, op=op, comm=comm)
+    return tuple(mpi_scan_p.bind(x, token, op=op, comm=comm))
 
 
 # This function compiles the operation

--- a/mpi4jax/_src/collective_ops/scatter.py
+++ b/mpi4jax/_src/collective_ops/scatter.py
@@ -19,6 +19,7 @@ from ..utils import (
 )
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
+from ..token_context import inject_ctx_token
 from ..comm import get_default_comm
 
 # The Jax primitive
@@ -32,9 +33,11 @@ mpi_scatter_impl = default_primitive_impl(mpi_scatter_p)
     comm=(type(None), _MPI.Intracomm, HashableMPIType),
     token=(type(None), xla.Token, core.Tracer),
 )
+@inject_ctx_token
 def scatter(
     x,
     root,
+    *,
     comm=None,
     token=None,
 ):
@@ -75,11 +78,13 @@ def scatter(
 
     comm = wrap_as_hashable(comm)
 
-    return mpi_scatter_p.bind(
-        x,
-        token,
-        root=root,
-        comm=comm,
+    return tuple(
+        mpi_scatter_p.bind(
+            x,
+            token,
+            root=root,
+            comm=comm,
+        )
     )
 
 

--- a/mpi4jax/_src/collective_ops/send.py
+++ b/mpi4jax/_src/collective_ops/send.py
@@ -19,6 +19,7 @@ from ..utils import (
 )
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
+from ..token_context import inject_ctx_token
 from ..comm import get_default_comm
 
 # The Jax primitive
@@ -33,7 +34,8 @@ mpi_send_impl = default_primitive_impl(mpi_send_p)
     comm=(type(None), _MPI.Intracomm, HashableMPIType),
     token=(type(None), xla.Token, core.Tracer),
 )
-def send(x, dest, tag=0, comm=None, token=None):
+@inject_ctx_token
+def send(x, dest, *, tag=0, comm=None, token=None):
     """Perform a send operation.
 
     Arguments:

--- a/mpi4jax/_src/token_context.py
+++ b/mpi4jax/_src/token_context.py
@@ -14,6 +14,9 @@ def token_context(token=None):
     if token is None:
         token = jax.lax.create_token()
 
+    if not isinstance(token, (Token, jax.core.Tracer)):
+        raise TypeError("First argument to token_context must be a token or None")
+
     try:
         ctx.token_stack.append(token)
         yield

--- a/mpi4jax/_src/token_context.py
+++ b/mpi4jax/_src/token_context.py
@@ -1,0 +1,65 @@
+import threading
+import functools
+from contextlib import contextmanager
+
+import jax
+from jax.interpreters.xla import Token
+
+ctx = threading.local()
+ctx.token_stack = []
+
+
+@contextmanager
+def token_context(token=None):
+    if token is None:
+        token = jax.lax.create_token()
+
+    try:
+        ctx.token_stack.append(token)
+        yield
+
+    finally:
+        ctx.token_stack.pop()
+
+
+def is_jitting():
+    dummy = jax.lax.create_token()
+    return not isinstance(dummy, Token)
+
+
+def inject_ctx_token(func):
+    @functools.wraps(func)
+    def wrapped(*args, token=None, **kwargs):
+        if token is None and len(ctx.token_stack) > 0:
+            token = ctx.token_stack[-1]
+
+        if is_jitting() and isinstance(token, Token):
+            raise RuntimeError(
+                "A token_context from non-JIT code cannot be used within JIT. "
+                "Consider moving token_context into your JITed function."
+            )
+
+        try:
+            res = func(*args, **kwargs, token=token)
+
+        except jax.core.UnexpectedTracerError as exc:
+            if not ctx.token_stack:
+                # token_context is not in use
+                raise
+
+            raise RuntimeError(
+                "Encountered unexpected tracer. Make sure not to use "
+                "token_context across more than one JIT function."
+            ) from exc
+
+        else:
+            if isinstance(res, tuple):
+                new_token = res[-1]
+            else:
+                new_token = res
+
+            ctx.token_stack[-1] = new_token
+
+        return res
+
+    return wrapped

--- a/tests/test_token_context.py
+++ b/tests/test_token_context.py
@@ -1,0 +1,111 @@
+import pytest
+
+from mpi4py import MPI
+
+import jax
+import jax.numpy as jnp
+
+
+def test_token_context():
+    from mpi4jax import allreduce, token_context
+    from mpi4jax._src.token_context import ctx
+
+    arr = jnp.ones((3, 2))
+
+    # with initial token
+    initial_token = jax.lax.create_token()
+    expected_addr = id(initial_token)
+
+    assert ctx.token_stack == []
+
+    with token_context(initial_token):
+        assert ctx.token_stack[0] is initial_token
+
+        res, token = allreduce(arr, op=MPI.SUM)
+        assert id(token) == expected_addr
+        res, token2 = allreduce(arr * 2, op=MPI.SUM)
+        assert id(token2) == expected_addr
+
+    assert ctx.token_stack == []
+
+    # without initial token
+    with token_context():
+        expected_addr = id(ctx.token_stack[-1])
+
+        res, token = allreduce(arr, op=MPI.SUM)
+        assert id(token) == expected_addr
+        res, token2 = allreduce(arr * 2, op=MPI.SUM)
+        assert id(token2) == expected_addr
+
+    assert ctx.token_stack == []
+
+
+def test_token_context_nested():
+    from mpi4jax import allreduce, token_context
+    from mpi4jax._src.token_context import ctx
+
+    arr = jnp.ones((3, 2))
+    initial_token = jax.lax.create_token()
+
+    with token_context(initial_token):
+        assert ctx.token_stack[0] is initial_token
+
+        res, token = allreduce(arr, op=MPI.SUM)
+        res, token2 = allreduce(arr * 2, op=MPI.SUM)
+
+        with token_context(token2):
+            assert len(ctx.token_stack) == 2
+            assert ctx.token_stack[1] is token2
+
+            res, token3 = allreduce(arr * 3, op=MPI.SUM)
+            assert ctx.token_stack[0] is token2
+            assert ctx.token_stack[1] is token3
+
+    assert ctx.token_stack == []
+
+
+def test_token_context_jit():
+    from mpi4jax import allreduce, token_context
+    from mpi4jax._src.token_context import ctx
+
+    arr = jnp.ones((3, 2))
+
+    @jax.jit
+    def bar(arr, initial_token=None):
+        with token_context(initial_token):
+            res1, token1 = allreduce(arr, op=MPI.SUM)
+            assert ctx.token_stack[-1] is token1
+            res2, token2 = allreduce(arr * 2, op=MPI.SUM)
+            assert ctx.token_stack[-1] is token2
+
+        return res1, res2
+
+    assert ctx.token_stack == []
+
+    bar(arr)
+
+    assert ctx.token_stack == []
+
+    with token_context():
+        res, token = allreduce(arr, op=MPI.SUM)
+        bar(arr, token)
+
+    assert ctx.token_stack == []
+
+
+def test_token_context_leak():
+    from mpi4jax import allreduce, token_context
+
+    arr = jnp.ones((3, 2))
+
+    @jax.jit
+    def foo(arr):
+        res1, _ = allreduce(arr, op=MPI.SUM)
+        res2, _ = allreduce(arr * 2, op=MPI.SUM)
+        return res1, res2
+
+    with pytest.raises(RuntimeError) as excinfo:
+        with token_context():
+            foo(arr)
+
+    assert "cannot be used within JIT" in str(excinfo.value)


### PR DESCRIPTION
This takes some ideas from #59 to address #82 and the discussion in #80.

The new feature is a context manager / decorator `token_context` that automatically threads tokens through all `mpi4jax` calls. It can be used like so:

```python
with token_context():
    res, _ = allreduce(arr, op=MPI.SUM)
    res, _ = allreduce(arr * 2, op=MPI.SUM)


@jax.jit
@token_context()
def foo(arr):
    res1, _ = allreduce(arr, op=MPI.SUM)
    res2, _ = allreduce(arr * 2, op=MPI.SUM)
    return res1, res2
```

But it cannot do this:

```python
@jax.jit
def foo(arr):
    res1, _ = allreduce(arr, op=MPI.SUM)
    res2, _ = allreduce(arr * 2, op=MPI.SUM)
    return res1, res2

with token_context():
    foo(arr)  # raises RuntimeError
```

Instead, each JITed function needs its own context:

```python
@jax.jit
def foo(arr, token):
    with token_context(token):
        res1, _ = allreduce(arr, op=MPI.SUM)
        res2, _ = allreduce(arr * 2, op=MPI.SUM)
    return res1, res2

with token_context():
    res1, token = allreduce(arr, op=MPI.SUM)
    foo(arr, token)  # works
```

Also fixes #75.