### PR TITLE
Fix for jax 0.2.14

### DIFF
--- a/examples/shallow_water.py
+++ b/examples/shallow_water.py
@@ -56,7 +56,7 @@ if mpi_size not in supported_nproc:
 nproc_y = min(mpi_size, 2)
 nproc_x = mpi_size // nproc_y
 
-proc_idx = jnp.unravel_index(mpi_rank, (nproc_y, nproc_x))
+proc_idx = np.unravel_index(mpi_rank, (nproc_y, nproc_x))
 
 #
 # Grid setup

--- a/mpi4jax/_src/collective_ops/allgather.py
+++ b/mpi4jax/_src/collective_ops/allgather.py
@@ -169,7 +169,7 @@ def mpi_allgather_abstract_eval(x, token, comm):
     out_shape = (size, *x.shape)
     return (
         abstract_arrays.ShapedArray(out_shape, x.dtype),
-        abstract_arrays.abstract_token,
+        core.abstract_token,
     )
 
 

--- a/mpi4jax/_src/collective_ops/allreduce.py
+++ b/mpi4jax/_src/collective_ops/allreduce.py
@@ -150,7 +150,7 @@ def mpi_allreduce_xla_encode_gpu(c, x, token, op, comm, transpose):
 def mpi_allreduce_abstract_eval(xs, token, op, comm, transpose):
     return (
         abstract_arrays.ShapedArray(xs.shape, xs.dtype),
-        abstract_arrays.abstract_token,
+        core.abstract_token,
     )
 
 

--- a/mpi4jax/_src/collective_ops/alltoall.py
+++ b/mpi4jax/_src/collective_ops/alltoall.py
@@ -167,7 +167,7 @@ def mpi_alltoall_xla_encode_gpu(c, x, token, comm):
 def mpi_alltoall_abstract_eval(xs, token, comm):
     return (
         abstract_arrays.ShapedArray(xs.shape, xs.dtype),
-        abstract_arrays.abstract_token,
+        core.abstract_token,
     )
 
 

--- a/mpi4jax/_src/collective_ops/barrier.py
+++ b/mpi4jax/_src/collective_ops/barrier.py
@@ -1,6 +1,6 @@
 from mpi4py import MPI as _MPI
 
-from jax import abstract_arrays, core
+from jax import core
 from jax.core import Primitive
 from jax.interpreters import xla, batching
 from jax.lax import create_token
@@ -103,7 +103,7 @@ def mpi_barrier_xla_encode_gpu(c, token, comm):
 
 # This function evaluates only the shapes during AST construction
 def mpi_barrier_abstract_eval(token, comm):
-    return abstract_arrays.abstract_token
+    return core.abstract_token
 
 
 def mpi_barrier_batch_eval(in_args, batch_axes, comm):

--- a/mpi4jax/_src/collective_ops/bcast.py
+++ b/mpi4jax/_src/collective_ops/bcast.py
@@ -156,7 +156,7 @@ def mpi_bcast_xla_encode_gpu(c, x, token, root, comm):
 def mpi_bcast_abstract_eval(xs, token, root, comm):
     return (
         abstract_arrays.ShapedArray(xs.shape, xs.dtype),
-        abstract_arrays.abstract_token,
+        core.abstract_token,
     )
 
 

--- a/mpi4jax/_src/collective_ops/gather.py
+++ b/mpi4jax/_src/collective_ops/gather.py
@@ -198,7 +198,7 @@ def mpi_gather_abstract_eval(x, token, root, comm):
 
     return (
         abstract_arrays.ShapedArray(out_shape, x.dtype),
-        abstract_arrays.abstract_token,
+        core.abstract_token,
     )
 
 

--- a/mpi4jax/_src/collective_ops/recv.py
+++ b/mpi4jax/_src/collective_ops/recv.py
@@ -179,7 +179,7 @@ def mpi_recv_xla_encode_gpu(c, x, token, source, tag, comm, status):
 def mpi_recv_abstract_eval(xs, token, source, tag, comm, status):
     return (
         abstract_arrays.ShapedArray(xs.shape, xs.dtype),
-        abstract_arrays.abstract_token,
+        core.abstract_token,
     )
 
 

--- a/mpi4jax/_src/collective_ops/reduce.py
+++ b/mpi4jax/_src/collective_ops/reduce.py
@@ -165,7 +165,7 @@ def mpi_reduce_xla_encode_gpu(c, x, token, op, root, comm):
 def mpi_reduce_abstract_eval(xs, token, op, root, comm):
     return (
         abstract_arrays.ShapedArray(xs.shape, xs.dtype),
-        abstract_arrays.abstract_token,
+        core.abstract_token,
     )
 
 

--- a/mpi4jax/_src/collective_ops/scan.py
+++ b/mpi4jax/_src/collective_ops/scan.py
@@ -139,7 +139,7 @@ def mpi_scan_xla_encode_gpu(c, x, token, op, comm):
 def mpi_scan_abstract_eval(xs, token, op, comm):
     return (
         abstract_arrays.ShapedArray(xs.shape, xs.dtype),
-        abstract_arrays.abstract_token,
+        core.abstract_token,
     )
 
 

--- a/mpi4jax/_src/collective_ops/scatter.py
+++ b/mpi4jax/_src/collective_ops/scatter.py
@@ -197,7 +197,7 @@ def mpi_scatter_abstract_eval(x, token, root, comm):
 
     return (
         abstract_arrays.ShapedArray(out_shape, x.dtype),
-        abstract_arrays.abstract_token,
+        core.abstract_token,
     )
 
 

--- a/mpi4jax/_src/collective_ops/send.py
+++ b/mpi4jax/_src/collective_ops/send.py
@@ -1,7 +1,7 @@
 import numpy as _np
 from mpi4py import MPI as _MPI
 
-from jax import abstract_arrays, core
+from jax import core
 from jax.core import Primitive
 from jax.interpreters import xla
 from jax.lax import create_token
@@ -136,7 +136,7 @@ def mpi_send_xla_encode_gpu(c, x, token, dest, tag, comm):
 
 # This function evaluates only the shapes during AST construction
 def mpi_send_abstract_eval(xs, token, dest, tag, comm):
-    return abstract_arrays.abstract_token
+    return core.abstract_token
 
 
 mpi_send_p.def_impl(mpi_send_impl)

--- a/mpi4jax/_src/collective_ops/sendrecv.py
+++ b/mpi4jax/_src/collective_ops/sendrecv.py
@@ -283,7 +283,7 @@ def mpi_sendrecv_abstract_eval(
 ):
     return (
         abstract_arrays.ShapedArray(recvbuf.shape, recvbuf.dtype),
-        abstract_arrays.abstract_token,
+        core.abstract_token,
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -211,5 +211,5 @@ setup(
     packages=find_packages(),
     ext_modules=get_extensions(),
     python_requires=">=3.6",
-    install_requires=["jax", "mpi4py>=3.0.1", "numpy"],
+    install_requires=["jax>=0.2.10", "mpi4py>=3.0.1", "numpy"],
 )

--- a/setup.py
+++ b/setup.py
@@ -211,5 +211,5 @@ setup(
     packages=find_packages(),
     ext_modules=get_extensions(),
     python_requires=">=3.6",
-    install_requires=["jax>=0.2.10", "mpi4py>=3.0.1", "numpy"],
+    install_requires=["jax>=0.2.9", "mpi4py>=3.0.1", "numpy"],
 )


### PR DESCRIPTION
`abstract_arrays.abstract_token` was removed.
Now we use `core.abstract_token` which is present in all version since `jax 0.2.10`.

I also added a version bound in setup.py for `jax>=0.2.9`.
This should change nothing because we throw a runtime error if `jaxlib<0.1.62` and `jax 0.2.9` is the oldest version compatible with it. 

BTW, we should add a tester running on the oldest jaxlib/jax combo to be sure we don't break nothing in the future...