### PR TITLE
Add --no-build-isolation recommendation to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,8 @@ With ``mpi4jax``, you can scale your JAX-based simulations to *entire CPU and GP
 In the spirit of differentiable programming, ``mpi4jax`` also supports differentiating through some MPI operations.
 
 
-Quick installation
-------------------
+Installation
+------------
 
 ``mpi4jax`` is available through ``pip`` and ``conda``:
 
@@ -26,7 +26,23 @@ Quick installation
    $ pip install mpi4jax                     # Pip
    $ conda install -c conda-forge mpi4jax    # conda
 
-Our documentation includes some more advanced installation examples.
+If you use pip and don't have JAX installed already, you will also need to do:
+
+.. code:: bash
+
+   $ pip install jaxlib
+
+(or an equivalent GPU-enabled version, `see the JAX installation instructions <https://github.com/google/jax#installation>`_)
+
+In case your MPI installation is not detected correctly, `it can help to install mpi4py separately <https://mpi4py.readthedocs.io/en/stable/install.html>`_. When using a pre-installed ``mpi4py``, you *must* use ``--no-build-isolation`` when installing ``mpi4jax``:
+
+.. code:: bash
+
+   # if mpi4py is already installed
+   $ pip install cython
+   $ pip install mpi4jax --no-build-isolation
+
+`Our documentation includes some more advanced installation examples. <https://mpi4jax.readthedocs.io/en/latest/installation.html>`_
 
 
 Example usage

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,6 +36,16 @@ Selecting the MPI distribution
 If ``mpi4py`` is not installed, it will be installed automatically before
 installing ``mpi4jax``.
 
+.. warning::
+
+   If ``mpi4py`` is already installed, you *must* use ``--no-build-isolation`` when installing ``mpi4jax``:
+
+   .. code:: bash
+
+      # if mpi4py is already installed
+      $ pip install cython
+      $ pip install mpi4jax --no-build-isolation
+
 To check which MPI library both libraries link to, run the following command in your
 prompt.
 
@@ -44,8 +54,8 @@ prompt.
 	$ python -c "import mpi4py; print(mpi4py.get_config())"
 
 If you wish to use a specific MPI library (only possible when using ``pip``), it is
-usually sufficient to specify the ``MPICC`` environment variable `before` installing
-```mpi4py``.
+usually sufficient to specify the ``MPICC`` environment variable *before* installing
+``mpi4py``.
 
 .. seealso::
 

--- a/setup.py
+++ b/setup.py
@@ -149,13 +149,18 @@ def cuda_info(cmd):
 
 
 def get_extensions():
-    if not HAS_MPI4PY:
-        print_warning("mpi4py could not be imported", "(extensions will not be built)")
-        return []
+    cmd = sys.argv[1]
+    require_extensions = any(
+        cmd.startswith(subcmd) for subcmd in ("install", "build", "bdist", "develop")
+    )
 
-    if not HAS_CYTHON:
-        print_warning("Cython could not be imported", "(extensions will not be built)")
-        return []
+    if not HAS_MPI4PY or not HAS_CYTHON:
+        # this should only happen when using python setup.py
+        # or pip install --no-build-isolation
+        if require_extensions:
+            raise RuntimeError("Building mpi4jax requires Cython and mpi4py")
+        else:
+            return []
 
     extensions = [
         Extension(


### PR DESCRIPTION
Addresses #102 #101 #100 #86.

Turns out, we cannot disable build isolation globally. Advising users to disable it manually if they want to use a pre-built ``mpi4py`` seems to be the best we can do.

``setup.py`` now fails loudly when build requirements are not available.