### PR TITLE
Better logging (including timing)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,9 +1,16 @@
 [flake8]
+# also track cython files
 filename = *.py, *.pyx
 per-file-ignores =
     # ignore some common false-positives in cython files
     *.pyx: E211, E225, E226, E999
-max-line-length = 88
+
+# ignore externals
 exclude =
     versioneer.py
     _version.py
+
+# for compatibility with black
+max-line-length = 88
+select = C,E,F,W,B,B950
+extend-ignore = E203,E501

--- a/mpi4jax/_src/xla_bridge/__init__.py
+++ b/mpi4jax/_src/xla_bridge/__init__.py
@@ -1,5 +1,7 @@
+import os
 from jax.lib import xla_client
 
+from . import mpi_xla_bridge
 from . import mpi_xla_bridge_cpu
 
 try:
@@ -8,6 +10,17 @@ except ImportError:
     HAS_GPU_EXT = False
 else:
     HAS_GPU_EXT = True
+
+
+# setup logging
+
+
+def _is_truthy(str_val):
+    return str_val.lower() in ("true", "1", "on")
+
+
+mpi_xla_bridge.set_logging(_is_truthy(os.getenv("MPI4JAX_DEBUG", "")))
+
 
 # register custom call targets
 for name, fn in mpi_xla_bridge_cpu.cpu_custom_call_targets.items():


### PR DESCRIPTION
Debug logs now look like this:

```bash
r0 | eH9MfhuG | MPI_Sendrecv <- 0 (tag -1, 182 items) / -> 0 (tag 0, 182 items)
r0 | eH9MfhuG | MPI_Sendrecv done with code 0 (3.65e-04s)
r0 | iFRGWyaK | MPI_Sendrecv <- 0 (tag -1, 182 items) / -> 0 (tag 0, 182 items)
r0 | iFRGWyaK | MPI_Sendrecv done with code 0 (1.62e-06s)
r0 | T1AarUMv | MPI_Sendrecv <- 0 (tag -1, 182 items) / -> 0 (tag 0, 182 items)
r0 | T1AarUMv | MPI_Sendrecv done with code 0 (8.90e-07s)
r0 | rGxB7xw2 | MPI_Sendrecv <- 0 (tag -1, 182 items) / -> 0 (tag 0, 182 items)
r0 | rGxB7xw2 | MPI_Sendrecv done with code 0 (1.11e-06s)
r0 | SRrekTrm | MPI_Sendrecv <- 0 (tag -1, 182 items) / -> 0 (tag 0, 182 items)
r0 | SRrekTrm | MPI_Sendrecv done with code 0 (8.11e-07s)
r0 | nQnmrtLY | MPI_Sendrecv <- 0 (tag -1, 182 items) / -> 0 (tag 0, 182 items)
r0 | nQnmrtLY | MPI_Sendrecv done with code 0 (7.36e-07s)
```

Notable changes:

- Random ID to identify overlapping calls (as suggested in #81)
- "done" messages including timing information
- Fixes a bug where `set_logging` didn't work as intended
- More robust tests