### PR TITLE
add `mpi4jax.has_cuda_support`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,3 +1,12 @@
+Utilities
+=========
+
+has_cuda_support
+----------------
+
+.. autofunction:: mpi4jax.has_cuda_support
+
+
 Communication primitives
 ========================
 

--- a/mpi4jax/__init__.py
+++ b/mpi4jax/__init__.py
@@ -19,6 +19,7 @@ from ._src import (  # noqa: E402
     scatter,
     send,
     sendrecv,
+    has_cuda_support,
 )
 
 __all__ = [
@@ -34,4 +35,5 @@ __all__ = [
     "scatter",
     "send",
     "sendrecv",
+    "has_cuda_support",
 ]

--- a/mpi4jax/_src/__init__.py
+++ b/mpi4jax/_src/__init__.py
@@ -19,10 +19,12 @@ from .collective_ops.scatter import scatter  # noqa: F401
 from .collective_ops.send import send  # noqa: F401
 from .collective_ops.sendrecv import sendrecv  # noqa: F401
 
+from .utils import has_cuda_support  # noqa: F401
+
 # check version of jaxlib
 from . import jax_compat
 
-jax_compat.check_jax_version()
+jax_compat.check_jax_version()  # noqa: F401
 
 # sanitize namespace
 del jax_compat, xla_bridge, MPI

--- a/mpi4jax/_src/utils.py
+++ b/mpi4jax/_src/utils.py
@@ -90,3 +90,15 @@ def unpack_hashable(obj):
         return obj.wrapped
 
     return obj
+
+
+# Miscellaneous Utilities
+
+
+def has_cuda_support() -> bool:
+    """Returns True if mpi4jax is built with CUDA support and can be used with GPU-based
+    jax-arrays, False otherwise.
+    """
+    from . import xla_bridge
+
+    return xla_bridge.HAS_GPU_EXT

--- a/tests/test_has_cuda.py
+++ b/tests/test_has_cuda.py
@@ -1,0 +1,4 @@
+def test_flush():
+    from mpi4jax import has_cuda_support
+
+    assert isinstance(has_cuda_support(), bool)


### PR DESCRIPTION
I was previously accessing this from netket to check if mpi4jax was built with cuda support.
Better make it a public API..