### PR TITLE
Use mpicc to build extensions

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -6,8 +6,9 @@ channels:
 
 dependencies:
   - python=3.7
-  - numpy
+  - openmpi-mpicc
   - mpi4py
+  - numpy
   - cython
   - sphinx
   - sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ def print_warning(*lines):
 
 def mpi_info(cmd):
     config = mpi4py.get_config()
-    cmd_compile = " ".join([config["mpicc"], "-show"])
+    cmd_compile = " ".join([config["mpicc"], "--cray-print-opts=cflags"])
     out_stream = os.popen(cmd_compile)
     flags = out_stream.read().strip()
     flags = flags.replace(",", " ").split()

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,11 @@ def print_warning(*lines):
 
 def mpi_info(cmd):
     config = mpi4py.get_config()
-    cmd_compile = " ".join([config["mpicc"], "--cray-print-opts=all"])
+    if 'CRAY_MPICH_VER' in os.environ:
+        show_flag = "--cray-print-opts=all"
+    else:
+        show_flag = "-show"
+    cmd_compile = " ".join([config["mpicc"], show_flag])
     out_stream = os.popen(cmd_compile)
     flags = out_stream.read().strip()
     flags = flags.replace(",", " ").split()

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import shlex
 
 from setuptools import setup, find_packages
 from setuptools.extension import Extension
@@ -69,11 +70,13 @@ def print_warning(*lines):
 class custom_build_ext(build_ext):
     def build_extensions(self):
         config = mpi4py.get_config()
-        mpi_compiler = config["mpicc"]
+
+        # on some platforms, mpi4py's compiler config includes flags
+        mpi_compiler = shlex.split(config["mpicc"])
 
         for exe in ("compiler", "compiler_so", "compiler_cxx", "linker_so"):
             current_flags = getattr(self.compiler, exe)[1:]
-            self.compiler.set_executable(exe, [mpi_compiler, *current_flags])
+            self.compiler.set_executable(exe, [*mpi_compiler, *current_flags])
 
         build_ext.build_extensions(self)
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ def print_warning(*lines):
 
 def mpi_info(cmd):
     config = mpi4py.get_config()
-    if 'CRAY_MPICH_VER' in os.environ:
+    if "CRAY_MPICH_VER" in os.environ:
         show_flag = "--cray-print-opts=all"
     else:
         show_flag = "-show"

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ def print_warning(*lines):
 
 def mpi_info(cmd):
     config = mpi4py.get_config()
-    cmd_compile = " ".join([config["mpicc"], "--cray-print-opts=cflags"])
+    cmd_compile = " ".join([config["mpicc"], "--cray-print-opts=all"])
     out_stream = os.popen(cmd_compile)
     flags = out_stream.read().strip()
     flags = flags.replace(",", " ").split()


### PR DESCRIPTION
Alternative to #155.

This will probably break when `mpicc` is a different compiler than the one Python was built with (for example `gcc` vs. `clang`). Not sure if that's a use case we want to support. In all other cases it should be far more robust than stripping paths from `mpicc -show`.