### PR TITLE
allow overriding mpi flags for non-openmpi compliant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,10 +66,13 @@ def print_warning(*lines):
 
 
 def mpi_info(cmd):
-    config = mpi4py.get_config()
-    cmd_compile = " ".join([config["mpicc"], "-show"])
-    out_stream = os.popen(cmd_compile)
-    flags = out_stream.read().strip()
+    if "MPICXX_FLAGS" in os.environ:
+        flags = os.environ["MPICXX_FLAGS"]
+    else:
+        config = mpi4py.get_config()
+        cmd_compile = " ".join([config["mpicc"], "-show"])
+        out_stream = os.popen(cmd_compile)
+        flags = out_stream.read().strip()
     flags = flags.replace(",", " ").split()
 
     if cmd == "compile":


### PR DESCRIPTION
This PR introduces an optional env var MPICXX_FLAGS as `cc -show` doesn't work on cray-mpich, for example.
In our system the user has to set `MPICXX_FLAGS=$(CC --cray-print-opts=all) CUDA_ROOT=... pip install mpi4jax --no-build-isolation`