### PR TITLE
allow effects for MPIEffect.

### DIFF
--- a/mpi4jax/_src/jax_compat.py
+++ b/mpi4jax/_src/jax_compat.py
@@ -19,6 +19,62 @@ def versiontuple(verstr):
     return tuple(int(v) for v in verstr.split("."))[:3]
 
 
+jax_version = versiontuple(jax.__version__)
+
+
+if jax_version >= versiontuple("0.3.15"):
+    # abstract eval needs to return effects
+    # see https://github.com/google/jax/issues/11620
+    from functools import wraps
+    from jax.interpreters import mlir
+    from jax._src.lax import control_flow as lcf
+
+    class MPIEffect:
+        def __hash__(self):
+            # enforce a constant (known) hash
+            return hash("I love mpi4jax")
+
+    effect = MPIEffect()
+    mlir.lowerable_effects.add(effect)
+    lcf.allowed_effects.add(effect)
+
+    # Effects must be added to the allow_effects list in order to work within
+    # custom_vjp. See google/jax#11916
+    if jax_version >= versiontuple("0.3.17"):
+        # since this is very internal, try not to break mpi4jax if they move the list.
+        has_allowed_effects_list = hasattr(jax._src, "custom_derivatives") and hasattr(
+            jax._src.custom_derivatives, "allowed_effects"
+        )
+        if has_allowed_effects_list:
+            jax._src.custom_derivatives.allowed_effects.add(effect)
+        else:
+            warnings.warn(
+                "\n`jax._src.custom_derivatives.allowed_effects` does not exist in this jax version, "
+                "so MPI operations might not work from within functions with custom vjp/jvp rules.\n\n"
+                "Try upgrading mpi4jax via\n\n"
+                "      $ pip install -U mpi4jax\n\n"
+                "and open an issue on the mpi4jax repository if the issue persists."
+            )
+
+    def register_abstract_eval(primitive, func):
+        """Injects an effect object into func and registers it via `primitive.def_effectful_abstract_eval`.
+
+        (as required by JAX>=0.3.15 to ensure primitives are staged out)
+        """
+
+        @wraps(func)
+        def effects_wrapper(*args, **kwargs):
+            return func(*args, **kwargs), {effect}
+
+        primitive.def_effectful_abstract_eval(effects_wrapper)
+
+else:
+    # TODO: drop this path when we require jax>=0.3.15
+
+    def register_abstract_eval(primitive, func):
+        primitive.def_abstract_eval(func)
+
+
 def check_jax_version():
     here = os.path.dirname(__file__)
     with open(os.path.join(here, "_latest_jax_version.txt")) as f:

--- a/mpi4jax/_src/utils.py
+++ b/mpi4jax/_src/utils.py
@@ -8,6 +8,7 @@ from jax.interpreters import xla, mlir
 import jaxlib.mlir.ir as ir
 from jaxlib.mlir.dialects import mhlo
 from jax._src.lax import control_flow as lcf
+import jax._src.custom_derivatives as custom_derivatives
 
 from .jax_compat import token_type
 
@@ -21,6 +22,9 @@ class MPIEffect:
 effect = MPIEffect()
 mlir.lowerable_effects.add(effect)
 lcf.allowed_effects.add(effect)
+# Effects must be added to the allow_effects list in order to work within
+# custom_vjp. See google/jax#11916
+custom_derivatives.allowed_effects.add(effect)
 
 
 def default_primitive_impl(primitive):

--- a/tests/collective_ops/test_allreduce.py
+++ b/tests/collective_ops/test_allreduce.py
@@ -224,10 +224,8 @@ def test_allreduce_chained_jit():
 def test_custom_vjp():
     from mpi4jax import allreduce
 
-    from jax import custom_vjp
-
     # define an arbitrary functin with custom_vjp
-    @custom_vjp
+    @jax.custom_vjp
     def f(x, y):
         r = jnp.sin(x) * y
         r = r.sum()
@@ -245,14 +243,13 @@ def test_custom_vjp():
     f.defvjp(f_fwd, f_bwd)
 
     # check that it does not crash
-    res_t = jax.jit(f)(jnp.ones(3), jnp.ones(3) * 2)
-    res_t = jax.jit(jax.grad(f))(jnp.ones(3), jnp.ones(3) * 2)
+    _ = jax.jit(f)(jnp.ones(3), jnp.ones(3) * 2)
+    _ = jax.jit(jax.grad(f))(jnp.ones(3), jnp.ones(3) * 2)
 
 
 def test_advanced_jvp():
     from mpi4jax import allreduce
     from functools import partial
-    from jax import custom_vjp
 
     def expect(
         log_pdf,

--- a/tests/collective_ops/test_allreduce.py
+++ b/tests/collective_ops/test_allreduce.py
@@ -307,5 +307,4 @@ def test_advanced_jvp():
     O, vjpfun = jax.vjp(
         lambda w: expect(log_pdf, expected_fun, w, x, None, n_chains=16), w
     )
-    print(f"O is {O} with {O.shape=}")
     vjpfun(jnp.ones_like(O))


### PR DESCRIPTION
Adds `MPIEffect` to the allowed_effect list in `custom_vjp/jvp` following the comment in https://github.com/google/jax/issues/11916 .

This is required, following the recent rewrite, in order to use MPI primitives within `custom_vjp/jvp` functions.
This only works with jax master because the allowed_effect list was not present in jax 3.15/3.16 , so it can't really be tested on CI right now, but local testing shows it works. 
