### PR TITLE
Workaround to enforce C contiguous memory layout of XLA inputs and output buffers

### DIFF
--- a/mpi4jax/_src/collective_ops/allgather.py
+++ b/mpi4jax/_src/collective_ops/allgather.py
@@ -21,6 +21,7 @@ from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
 from ..jax_compat import register_abstract_eval
+from ..layout_helper import enforce_layout
 
 # The Jax primitive
 mpi_allgather_p = Primitive("allgather_mpi")  # Create the primitive
@@ -28,6 +29,7 @@ mpi_allgather_impl = default_primitive_impl(mpi_allgather_p)
 
 
 # This function applies the primitive to an AST
+@enforce_layout
 @enforce_types(
     comm=(type(None), _MPI.Intracomm, HashableMPIType),
     token=(type(None), Token, Tracer),

--- a/mpi4jax/_src/collective_ops/allreduce.py
+++ b/mpi4jax/_src/collective_ops/allreduce.py
@@ -21,6 +21,7 @@ from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
 from ..jax_compat import register_abstract_eval
+from ..layout_helper import enforce_layout
 
 # The Jax primitive
 mpi_allreduce_p = Primitive("allreduce_mpi")  # Create the primitive
@@ -28,6 +29,7 @@ mpi_allreduce_impl = default_primitive_impl(mpi_allreduce_p)
 
 
 # This function applies the primitive to an AST
+@enforce_layout
 @enforce_types(
     op=(_MPI.Op, HashableMPIType),
     comm=(type(None), _MPI.Intracomm, HashableMPIType),

--- a/mpi4jax/_src/collective_ops/allreduce.py
+++ b/mpi4jax/_src/collective_ops/allreduce.py
@@ -21,7 +21,6 @@ from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
 from ..jax_compat import register_abstract_eval
-from ..layout_helper import enforce_layout
 
 # The Jax primitive
 mpi_allreduce_p = Primitive("allreduce_mpi")  # Create the primitive
@@ -29,7 +28,6 @@ mpi_allreduce_impl = default_primitive_impl(mpi_allreduce_p)
 
 
 # This function applies the primitive to an AST
-@enforce_layout
 @enforce_types(
     op=(_MPI.Op, HashableMPIType),
     comm=(type(None), _MPI.Intracomm, HashableMPIType),

--- a/mpi4jax/_src/collective_ops/alltoall.py
+++ b/mpi4jax/_src/collective_ops/alltoall.py
@@ -67,11 +67,13 @@ def alltoall(
 
     comm = wrap_as_hashable(comm)
 
-    return tuple(mpi_alltoall_p.bind(
+    return tuple(
+        mpi_alltoall_p.bind(
             x,
             token,
             comm=comm,
-        ))
+        )
+    )
 
 
 # This function compiles the operation

--- a/mpi4jax/_src/collective_ops/bcast.py
+++ b/mpi4jax/_src/collective_ops/bcast.py
@@ -21,6 +21,7 @@ from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
 from ..jax_compat import register_abstract_eval
+from ..layout_helper import enforce_layout
 
 # The Jax primitive
 mpi_bcast_p = Primitive("bcast_mpi")  # Create the primitive
@@ -28,6 +29,7 @@ mpi_bcast_impl = default_primitive_impl(mpi_bcast_p)
 
 
 # This function applies the primitive to an AST
+@enforce_layout
 @enforce_types(
     root=(_np.integer),
     comm=(type(None), _MPI.Intracomm, HashableMPIType),

--- a/mpi4jax/_src/collective_ops/gather.py
+++ b/mpi4jax/_src/collective_ops/gather.py
@@ -21,6 +21,7 @@ from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
 from ..jax_compat import register_abstract_eval
+from ..layout_helper import enforce_layout
 
 # The Jax primitive
 mpi_gather_p = Primitive("gather_mpi")  # Create the primitive
@@ -28,6 +29,7 @@ mpi_gather_impl = default_primitive_impl(mpi_gather_p)
 
 
 # This function applies the primitive to an AST
+@enforce_layout
 @enforce_types(
     root=(_np.integer),
     comm=(type(None), _MPI.Intracomm, HashableMPIType),

--- a/mpi4jax/_src/collective_ops/recv.py
+++ b/mpi4jax/_src/collective_ops/recv.py
@@ -22,6 +22,7 @@ from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
 from ..jax_compat import register_abstract_eval
+from ..layout_helper import enforce_layout
 
 # The Jax primitive
 mpi_recv_p = Primitive("recv_mpi")  # Create the primitive
@@ -29,6 +30,7 @@ mpi_recv_impl = default_primitive_impl(mpi_recv_p)
 
 
 # This function applies the primitive to an AST
+@enforce_layout
 @enforce_types(
     source=_np.integer,
     tag=_np.integer,

--- a/mpi4jax/_src/collective_ops/reduce.py
+++ b/mpi4jax/_src/collective_ops/reduce.py
@@ -21,6 +21,7 @@ from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
 from ..jax_compat import register_abstract_eval
+from ..layout_helper import enforce_layout
 
 # The Jax primitive
 mpi_reduce_p = Primitive("reduce_mpi")  # Create the primitive
@@ -28,6 +29,7 @@ mpi_reduce_impl = default_primitive_impl(mpi_reduce_p)
 
 
 # This function applies the primitive to an AST
+@enforce_layout
 @enforce_types(
     op=(_MPI.Op, HashableMPIType),
     root=(_np.integer),

--- a/mpi4jax/_src/collective_ops/scan.py
+++ b/mpi4jax/_src/collective_ops/scan.py
@@ -21,6 +21,7 @@ from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
 from ..jax_compat import register_abstract_eval
+from ..layout_helper import enforce_layout
 
 # The Jax primitive
 mpi_scan_p = Primitive("scan_mpi")  # Create the primitive
@@ -28,6 +29,7 @@ mpi_scan_impl = default_primitive_impl(mpi_scan_p)
 
 
 # This function applies the primitive to an AST
+@enforce_layout
 @enforce_types(
     op=(_MPI.Op, HashableMPIType),
     comm=(type(None), _MPI.Intracomm, HashableMPIType),

--- a/mpi4jax/_src/collective_ops/scatter.py
+++ b/mpi4jax/_src/collective_ops/scatter.py
@@ -21,6 +21,7 @@ from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
 from ..jax_compat import register_abstract_eval
+from ..layout_helper import enforce_layout
 
 # The Jax primitive
 mpi_scatter_p = Primitive("scatter_mpi")  # Create the primitive
@@ -28,6 +29,7 @@ mpi_scatter_impl = default_primitive_impl(mpi_scatter_p)
 
 
 # This function applies the primitive to an AST
+@enforce_layout
 @enforce_types(
     root=(_np.integer),
     comm=(type(None), _MPI.Intracomm, HashableMPIType),

--- a/mpi4jax/_src/collective_ops/send.py
+++ b/mpi4jax/_src/collective_ops/send.py
@@ -21,6 +21,7 @@ from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
 from ..jax_compat import register_abstract_eval
+from ..layout_helper import enforce_layout
 
 # The Jax primitive
 mpi_send_p = Primitive("send_mpi")  # Create the primitive
@@ -28,6 +29,7 @@ mpi_send_impl = default_primitive_impl(mpi_send_p)
 
 
 # This function applies the primitive to an AST
+@enforce_layout
 @enforce_types(
     dest=_np.integer,
     tag=_np.integer,

--- a/mpi4jax/_src/collective_ops/sendrecv.py
+++ b/mpi4jax/_src/collective_ops/sendrecv.py
@@ -22,6 +22,7 @@ from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
 from ..jax_compat import register_abstract_eval
+from ..layout_helper import enforce_layout
 
 # The Jax primitive
 mpi_sendrecv_p = Primitive("sendrecv_mpi")  # Create the primitive
@@ -29,6 +30,7 @@ mpi_sendrecv_impl = default_primitive_impl(mpi_sendrecv_p)
 
 
 # This function applies the primitive to an AST
+@enforce_layout
 @enforce_types(
     source=_np.integer,
     dest=_np.integer,

--- a/mpi4jax/_src/collective_ops/sendrecv.py
+++ b/mpi4jax/_src/collective_ops/sendrecv.py
@@ -88,10 +88,8 @@ def sendrecv(
     if status is not None:
         status = wrap_as_hashable(status)
 
-    # TODO: remove ascontiguousarray when https://github.com/google/jax/issues/13187 is resolved
     sendbuf = ascontiguousarray(sendbuf)
-
-    x, token = mpi_sendrecv_p.bind(
+    recvbuf, token = mpi_sendrecv_p.bind(
         sendbuf,
         recvbuf,
         token,
@@ -103,8 +101,7 @@ def sendrecv(
         status=status,
         _must_transpose=False,
     )
-
-    return ascontiguousarray(x), token
+    return ascontiguousarray(recvbuf), token
 
 
 # This function compiles the operation

--- a/mpi4jax/_src/layout_helper.py
+++ b/mpi4jax/_src/layout_helper.py
@@ -94,7 +94,7 @@ def ascontiguousarray_abstract_eval(xs):
 
 
 def ascontiguousarray_batch_eval(in_args, batch_axes):
-    return ascontiguousarray(*in_args), batch_axes
+    return ascontiguousarray(*in_args), batch_axes[0]
 
 
 def ascontiguousarray_value_and_jvp(arg_values, arg_tangents):

--- a/mpi4jax/_src/layout_helper.py
+++ b/mpi4jax/_src/layout_helper.py
@@ -1,7 +1,7 @@
 from jax import abstract_arrays
 from jax.core import Primitive
 
-from .utils import  default_primitive_impl
+from .utils import default_primitive_impl
 
 from .decorators import translation_rule_cpu, translation_rule_gpu
 from .jax_compat import register_abstract_eval
@@ -15,78 +15,90 @@ import functools
 ascontiguousarray_p = Primitive("ascontiguousarray")  # Create the primitive
 ascontiguousarray_impl = default_primitive_impl(ascontiguousarray_p)
 
+
 def enforce_layout(function):
-    """ Decorator that enforces that both input and output
+    """Decorator that enforces that both input and output
     of the collective operations are in C contiguous order
     """
+
     @functools.wraps(function)
     def wrapped(x, *args, **kwargs):
         x = ascontiguousarray(x)
         out = function(x, *args, **kwargs)
-        if function.__name__ == 'send':
+        if function.__name__ == "send":
             return out
         else:
             x, token = out
             x = ascontiguousarray(x)
             return x, token
+
     return wrapped
+
 
 def ascontiguousarray(
     x,
 ):
-    """ Enforces the layout of a given tensor to be C contiguous.
+    """Enforces the layout of a given tensor to be C contiguous.
     If the array already has C layout, nothing happens.
 
     Arguments:
         x: Array input to potentially reorder
-    
+
     Returns:
         Reordered array
     """
     return ascontiguousarray_p.bind(
-            x,
-        )
+        x,
+    )
+
 
 @translation_rule_gpu
 def ascontiguousarray_xla_encode_gpu(ctx, x):
     dtype = ir.RankedTensorType(x.type)
     dims = dtype.shape
     layout = tuple(range(len(dims) - 1, -1, -1))
-    return [custom_call(
+    return [
+        custom_call(
             b"ascontiguousarray",
-        [dtype],
-        [x],
-        backend_config=None,
-        operand_layouts=[layout],
-        result_layouts=[layout],
-        operand_output_aliases={0:0})]
+            [dtype],
+            [x],
+            backend_config=None,
+            operand_layouts=[layout],
+            result_layouts=[layout],
+            operand_output_aliases={0: 0},
+        )
+    ]
+
 
 @translation_rule_cpu
 def ascontiguousarray_xla_encode_cpu(ctx, x):
     dtype = ir.RankedTensorType(x.type)
     dims = dtype.shape
     layout = tuple(range(len(dims) - 1, -1, -1))
-    return [custom_call(
+    return [
+        custom_call(
             b"ascontiguousarray",
-        [dtype],
-        [x],
-        backend_config=None,
-        operand_layouts=[layout],
-        result_layouts=[layout],
-        operand_output_aliases={0:0})]     
+            [dtype],
+            [x],
+            backend_config=None,
+            operand_layouts=[layout],
+            result_layouts=[layout],
+            operand_output_aliases={0: 0},
+        )
+    ]
+
 
 # This function evaluates only the shapes during AST construction
 def ascontiguousarray_abstract_eval(xs):
     return abstract_arrays.ShapedArray(xs.shape, xs.dtype)
 
+
 ascontiguousarray_p.def_impl(ascontiguousarray_impl)
 register_abstract_eval(ascontiguousarray_p, ascontiguousarray_abstract_eval)
 
 mlir.register_lowering(
-    ascontiguousarray_p,
-    ascontiguousarray_xla_encode_gpu,
-    platform='gpu')
+    ascontiguousarray_p, ascontiguousarray_xla_encode_gpu, platform="gpu"
+)
 mlir.register_lowering(
-    ascontiguousarray_p,
-    ascontiguousarray_xla_encode_cpu,
-    platform='cpu')
+    ascontiguousarray_p, ascontiguousarray_xla_encode_cpu, platform="cpu"
+)

--- a/mpi4jax/_src/layout_helper.py
+++ b/mpi4jax/_src/layout_helper.py
@@ -1,0 +1,75 @@
+from jax import abstract_arrays
+from jax.core import Primitive
+
+from .utils import  default_primitive_impl
+
+from .decorators import translation_rule_cpu, translation_rule_gpu
+from .jax_compat import register_abstract_eval
+
+import jaxlib.mlir.ir as ir
+from jax.interpreters import mlir
+from jaxlib.mhlo_helpers import custom_call
+
+# The Jax primitive
+ascontiguousarray_p = Primitive("ascontiguousarray")  # Create the primitive
+ascontiguousarray_impl = default_primitive_impl(ascontiguousarray_p)
+
+def ascontiguousarray(
+    x,
+):
+    """ Enforces the layout of a given tensor to be C contiguous.
+    If the array already has C layout, nothing happens.
+
+    Arguments:
+        x: Array input to potentially reorder
+    
+    Returns:
+        Reordered array
+    """
+    return ascontiguousarray_p.bind(
+            x,
+        )
+
+@translation_rule_gpu
+def ascontiguousarray_xla_encode_gpu(ctx, x):
+    dtype = ir.RankedTensorType(x.type)
+    dims = dtype.shape
+    layout = tuple(range(len(dims) - 1, -1, -1))
+    return [custom_call(
+            b"ascontiguousarray",
+        [dtype],
+        [x],
+        backend_config=None,
+        operand_layouts=[layout],
+        result_layouts=[layout],
+        operand_output_aliases={0:0})]
+
+@translation_rule_cpu
+def ascontiguousarray_xla_encode_cpu(ctx, x):
+    dtype = ir.RankedTensorType(x.type)
+    dims = dtype.shape
+    layout = tuple(range(len(dims) - 1, -1, -1))
+    return [custom_call(
+            b"ascontiguousarray",
+        [dtype],
+        [x],
+        backend_config=None,
+        operand_layouts=[layout],
+        result_layouts=[layout],
+        operand_output_aliases={0:0})]     
+
+# This function evaluates only the shapes during AST construction
+def ascontiguousarray_abstract_eval(xs):
+    return abstract_arrays.ShapedArray(xs.shape, xs.dtype)
+
+ascontiguousarray_p.def_impl(ascontiguousarray_impl)
+register_abstract_eval(ascontiguousarray_p, ascontiguousarray_abstract_eval)
+
+mlir.register_lowering(
+    ascontiguousarray_p,
+    ascontiguousarray_xla_encode_gpu,
+    platform='gpu')
+mlir.register_lowering(
+    ascontiguousarray_p,
+    ascontiguousarray_xla_encode_cpu,
+    platform='cpu')

--- a/mpi4jax/_src/xla_bridge/mpi_xla_bridge_cpu.pyx
+++ b/mpi4jax/_src/xla_bridge/mpi_xla_bridge_cpu.pyx
@@ -17,6 +17,16 @@ from . cimport mpi_xla_bridge
 #
 # CPU XLA targets
 #
+
+# Layout enforcement op
+
+cdef void ascontiguousarray_cpu(void** out_ptr, void** data_ptr) nogil:
+    """ This op does not actually need to do anything, the input and output
+    arrays are shared, no copy is necessary, XLA will take care of doing the
+    memory rearangement for us
+    """
+    pass
+
 cdef void mpi_barrier_cpu(void** out_ptr, void** data_ptr) nogil:
     cdef MPI_Comm comm = <MPI_Comm>((<uintptr_t*>(data_ptr[0]))[0])
     mpi_xla_bridge.mpi_barrier(comm)
@@ -195,6 +205,7 @@ cdef register_custom_call_target(fn_name, void* fn):
     cdef const char* name = "xla._CUSTOM_CALL_TARGET"
     cpu_custom_call_targets[fn_name] = PyCapsule_New(fn, name, NULL)
 
+register_custom_call_target(b"ascontiguousarray", <void*>(ascontiguousarray_cpu))
 register_custom_call_target(b"mpi_allgather", <void*>(mpi_allgather_cpu))
 register_custom_call_target(b"mpi_allreduce", <void*>(mpi_allreduce_cpu))
 register_custom_call_target(b"mpi_alltoall", <void*>(mpi_alltoall_cpu))

--- a/mpi4jax/_src/xla_bridge/mpi_xla_bridge_gpu.pyx
+++ b/mpi4jax/_src/xla_bridge/mpi_xla_bridge_gpu.pyx
@@ -110,6 +110,16 @@ cdef inline cudaError_t checked_cuda_stream_synchronize(
 # GPU XLA targets
 #
 
+# Layout enforcement op
+
+cdef void ascontiguousarray_gpu(cudaStream_t stream, void** buffers,
+                            const char* opaque, size_t opaque_len) nogil:
+    """ This op does not actually need to do anything, the input and output
+    arrays are shared, no copy is necessary, XLA will take care of doing the
+    memory rearangement for us
+    """
+    pass
+
 # Allgather
 
 cdef struct AllgatherDescriptor:
@@ -932,6 +942,7 @@ cdef register_custom_call_target(fn_name, void* fn):
     gpu_custom_call_targets[fn_name] = PyCapsule_New(fn, name, NULL)
 
 
+register_custom_call_target(b"ascontiguousarray", <void*>(ascontiguousarray_gpu))
 register_custom_call_target(b"mpi_allgather", <void*>(mpi_allgather_gpu))
 register_custom_call_target(b"mpi_allreduce", <void*>(mpi_allreduce_gpu))
 register_custom_call_target(b"mpi_alltoall", <void*>(mpi_alltoall_gpu))


### PR DESCRIPTION
This PR proposes a temporary fix for the issue identified in #176 . Ideally, we should be able to impose a given layout directly in the translation rule for the GPU and CPU ops, however, because XLA isn't happy with the combination of tokens and layouts this is a workaround that tricks XLA into reordering the arrays correctly using a dummy op that does nothing,but doesnt use tokens as inputs, and so for which we can specify the desired memory layout.

In my experiments, I've found that it is necessary to enforce the layout both before and after the collective.  So, my solution is to add a decorator `@enforce_layout` that I've added on top of all operations, and this decorator only contains roughly the following code:
```python
def enforce_layout(function):
    @functools.wraps(function)
    def wrapped(x, *args, **kwargs):
        x = ascontiguousarray(x)
        x, token= function(x, *args, **kwargs)
        x = ascontiguousarray(x)
        return x, token
    return wrapped
```

`ascontiguousarray` is a new custom op, defined [here](https://github.com/EiffL/mpi4jax/blob/585549a48acf14574812d2d6b988da6720eabe50/mpi4jax/_src/layout_helper.py#L34) that does literaly nothing. Here is it's cython content:
```python
cdef void ascontiguousarray_gpu(cudaStream_t stream, void** buffers,
                            const char* opaque, size_t opaque_len) nogil:
    pass
```
but thanks to the new MLIR translation rule, we can use aliasing, i.e. it will automatically define the output buffer to match the input buffer, so no memory operations are required. And, since this op only acts on `x` we can specify a layout:
```python
def ascontiguousarray_xla_encode_gpu(ctx, x):
    dtype = ir.RankedTensorType(x.type)
    dims = dtype.shape
    layout = tuple(range(len(dims) - 1, -1, -1))
    return [custom_call(
            b"ascontiguousarray",
        [dtype],
        [x],
        backend_config=None,
        operand_layouts=[layout],
        result_layouts=[layout],
        operand_output_aliases={0:0})]
```

It's not the ideal solution, but I also think it shouldn't have any impact on performance and memory usage. It's only a trick to ask XLA to please specify the memory layout. 