### PR TITLE
Drop python 3.7 and jax 0.3

### DIFF
--- a/.github/workflows/mpi-tests.yml
+++ b/.github/workflows/mpi-tests.yml
@@ -16,21 +16,21 @@ jobs:
 
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         mpi: [mpich, openmpi]
         jax-version: ["latest"]
 
         include:
-          # test intelmpi
+          # test intelmpi on Linux
           - os: ubuntu-22.04
-            python-version: "3.10"
+            python-version: "3.11"
             mpi: intelmpi
             jax-version: "latest"
           # test minimum JAX and Python versions
           - os: ubuntu-latest
             python-version: "3.8"
             mpi: openmpi
-            jax-version: "0.3.25"
+            jax-version: "0.4.4"
 
     env:
        MPICH_INTERFACE_HOSTNAME: localhost

--- a/.github/workflows/mpi-tests.yml
+++ b/.github/workflows/mpi-tests.yml
@@ -30,7 +30,7 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.8"
             mpi: openmpi
-            jax-version: "0.4.4"
+            jax-version: "0.4.5"
 
     env:
        MPICH_INTERFACE_HOSTNAME: localhost

--- a/.github/workflows/mpi-tests.yml
+++ b/.github/workflows/mpi-tests.yml
@@ -28,7 +28,7 @@ jobs:
             jax-version: "latest"
           # test minimum JAX and Python versions
           - os: ubuntu-latest
-            python-version: "3.7"
+            python-version: "3.8"
             mpi: openmpi
             jax-version: "0.3.25"
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -72,18 +72,3 @@ sendrecv
 ++++++++
 
 .. autofunction:: mpi4jax.sendrecv
-
-
-Experimental
-------------
-
-auto_tokenize
-+++++++++++++
-
-.. warning::
-
-    ``auto_tokenize`` is currently broken for JAX 0.4.4 and later.
-    To use it, downgrade to ``jax<=0.4.3``.
-    See `issue #192 <https://github.com/mpi4jax/mpi4jax/issues/192>`_ for more details.
-
-.. autofunction:: mpi4jax.experimental.auto_tokenize

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -15,4 +15,4 @@ dependencies:
   - pip
   - pip:
     # JAX is behind on conda-forge, seems like pip is better supported
-    - jax[cpu]<=0.4.3
+    - jax[cpu]

--- a/examples/shallow_water.py
+++ b/examples/shallow_water.py
@@ -424,7 +424,7 @@ def solve_shallow_water(t1, num_multisteps=10):
     """Iterate the model forward in time."""
     # initial conditions
     h, u, v = get_initial_conditions()
-    du, dv, dh = [jnp.zeros((ny_local, nx_local)) for _ in range(3)]
+    du, dv, dh = (jnp.zeros((ny_local, nx_local)) for _ in range(3))
 
     state = ModelState(h, u, v, dh, du, dv)
     sol = [state]

--- a/mpi4jax/_src/collective_ops/allgather.py
+++ b/mpi4jax/_src/collective_ops/allgather.py
@@ -19,7 +19,7 @@ from ..utils import (
     get_default_layouts,
     effect,
 )
-from ..jax_compat import hlo_custom_call, token_type, ShapedArray
+from ..jax_compat import custom_call, token_type, ShapedArray
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
@@ -111,7 +111,7 @@ def mpi_allgather_xla_encode_cpu(ctx, sendbuf, token, comm):
         token,
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_allgather",
         result_types=out_types,
         operands=operands,
@@ -159,7 +159,7 @@ def mpi_allgather_xla_encode_gpu(ctx, sendbuf, token, comm):
 
     operands = (sendbuf, token)
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_allgather",
         result_types=out_types,
         operands=operands,

--- a/mpi4jax/_src/collective_ops/allreduce.py
+++ b/mpi4jax/_src/collective_ops/allreduce.py
@@ -20,7 +20,7 @@ from ..utils import (
     get_default_layouts,
     effect,
 )
-from ..jax_compat import hlo_custom_call, token_type, ShapedArray
+from ..jax_compat import custom_call, token_type, ShapedArray
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
@@ -106,7 +106,7 @@ def mpi_allreduce_xla_encode_cpu(ctx, x, token, op, comm, transpose):
         token,
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_allreduce",
         result_types=out_types,
         operands=operands,
@@ -154,7 +154,7 @@ def mpi_allreduce_xla_encode_gpu(ctx, x, token, op, comm, transpose):
         to_dtype_handle(x_nptype),
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_allreduce",
         out_types=out_types,
         operands=operands,

--- a/mpi4jax/_src/collective_ops/alltoall.py
+++ b/mpi4jax/_src/collective_ops/alltoall.py
@@ -19,7 +19,7 @@ from ..utils import (
     get_default_layouts,
     effect,
 )
-from ..jax_compat import hlo_custom_call, token_type, ShapedArray
+from ..jax_compat import custom_call, token_type, ShapedArray
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
@@ -112,7 +112,7 @@ def mpi_alltoall_xla_encode_cpu(ctx, x, token, comm):
         token,
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_alltoall",
         result_types=out_types,
         operands=operands,
@@ -162,7 +162,7 @@ def mpi_alltoall_xla_encode_gpu(ctx, x, token, comm):
         to_mpi_handle(comm),
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_alltoall",
         out_types=out_types,
         operands=operands,

--- a/mpi4jax/_src/collective_ops/barrier.py
+++ b/mpi4jax/_src/collective_ops/barrier.py
@@ -18,7 +18,7 @@ from ..utils import (
     get_default_layouts,
     effect,
 )
-from ..jax_compat import hlo_custom_call, token_type
+from ..jax_compat import custom_call, token_type
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
@@ -72,7 +72,7 @@ def mpi_barrier_xla_encode_cpu(ctx, token, comm):
         token,
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_barrier",
         result_types=out_types,
         operands=operands,
@@ -94,7 +94,7 @@ def mpi_barrier_xla_encode_gpu(ctx, token, comm):
 
     descriptor = build_barrier_descriptor(to_mpi_handle(comm))
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_barrier",
         result_types=out_types,
         operands=operands,

--- a/mpi4jax/_src/collective_ops/bcast.py
+++ b/mpi4jax/_src/collective_ops/bcast.py
@@ -19,7 +19,7 @@ from ..utils import (
     get_default_layouts,
     effect,
 )
-from ..jax_compat import hlo_custom_call, token_type, ShapedArray
+from ..jax_compat import custom_call, token_type, ShapedArray
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
@@ -110,7 +110,7 @@ def mpi_bcast_xla_encode_cpu(ctx, x, token, root, comm):
         token,
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_bcast",
         result_types=out_types,
         operands=operands,
@@ -159,7 +159,7 @@ def mpi_bcast_xla_encode_gpu(ctx, x, token, root, comm):
         dtype_handle,
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_bcast",
         result_types=out_types,
         operands=operands,

--- a/mpi4jax/_src/collective_ops/gather.py
+++ b/mpi4jax/_src/collective_ops/gather.py
@@ -19,7 +19,7 @@ from ..utils import (
     get_default_layouts,
     effect,
 )
-from ..jax_compat import hlo_custom_call, token_type, ShapedArray
+from ..jax_compat import custom_call, token_type, ShapedArray
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
@@ -133,7 +133,7 @@ def mpi_gather_xla_encode_cpu(ctx, x, token, root, comm):
         token,
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_gather",
         result_types=out_types,
         operands=operands,
@@ -191,7 +191,7 @@ def mpi_gather_xla_encode_gpu(ctx, x, token, root, comm):
         to_mpi_handle(comm),
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_gather",
         result_types=out_types,
         operands=operands,

--- a/mpi4jax/_src/collective_ops/recv.py
+++ b/mpi4jax/_src/collective_ops/recv.py
@@ -20,7 +20,7 @@ from ..utils import (
     get_default_layouts,
     effect,
 )
-from ..jax_compat import hlo_custom_call, token_type, ShapedArray
+from ..jax_compat import custom_call, token_type, ShapedArray
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
@@ -126,7 +126,7 @@ def mpi_recv_xla_encode_cpu(ctx, x, token, source, tag, comm, status):
         token,
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_recv",
         result_types=out_types,
         operands=operands,
@@ -176,7 +176,7 @@ def mpi_recv_xla_encode_gpu(ctx, x, token, source, tag, comm, status):
         status_ptr,
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_recv",
         result_types=out_types,
         operands=operands,

--- a/mpi4jax/_src/collective_ops/reduce.py
+++ b/mpi4jax/_src/collective_ops/reduce.py
@@ -19,7 +19,7 @@ from ..utils import (
     get_default_layouts,
     effect,
 )
-from ..jax_compat import hlo_custom_call, token_type, ShapedArray
+from ..jax_compat import custom_call, token_type, ShapedArray
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
@@ -113,7 +113,7 @@ def mpi_reduce_xla_encode_cpu(ctx, x, token, op, root, comm):
         token,
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_reduce",
         result_types=out_types,
         operands=operands,
@@ -166,7 +166,7 @@ def mpi_reduce_xla_encode_gpu(ctx, x, token, op, root, comm):
         dtype_handle,
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_reduce",
         result_types=out_types,
         operands=operands,

--- a/mpi4jax/_src/collective_ops/scan.py
+++ b/mpi4jax/_src/collective_ops/scan.py
@@ -19,7 +19,7 @@ from ..utils import (
     get_default_layouts,
     effect,
 )
-from ..jax_compat import hlo_custom_call, token_type, ShapedArray
+from ..jax_compat import custom_call, token_type, ShapedArray
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
@@ -96,7 +96,7 @@ def mpi_scan_xla_encode_cpu(ctx, x, token, op, comm):
         token,
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_scan",
         result_types=out_types,
         operands=operands,
@@ -142,7 +142,7 @@ def mpi_scan_xla_encode_gpu(ctx, x, token, op, comm):
         dtype_handle,
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_scan",
         result_types=out_types,
         operands=operands,

--- a/mpi4jax/_src/collective_ops/scatter.py
+++ b/mpi4jax/_src/collective_ops/scatter.py
@@ -19,7 +19,7 @@ from ..utils import (
     get_default_layouts,
     effect,
 )
-from ..jax_compat import hlo_custom_call, token_type, ShapedArray
+from ..jax_compat import custom_call, token_type, ShapedArray
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
@@ -133,7 +133,7 @@ def mpi_scatter_xla_encode_cpu(ctx, x, token, root, comm):
         token,
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_scatter",
         result_types=out_types,
         operands=operands,
@@ -185,7 +185,7 @@ def mpi_scatter_xla_encode_gpu(ctx, x, token, root, comm):
         to_mpi_handle(comm),
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_scatter",
         result_types=out_types,
         operands=operands,

--- a/mpi4jax/_src/collective_ops/send.py
+++ b/mpi4jax/_src/collective_ops/send.py
@@ -19,7 +19,7 @@ from ..utils import (
     get_default_layouts,
     effect,
 )
-from ..jax_compat import hlo_custom_call, token_type
+from ..jax_compat import custom_call, token_type
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
@@ -90,7 +90,7 @@ def mpi_send_xla_encode_cpu(ctx, x, token, dest, tag, comm):
         token,
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_send",
         result_types=out_types,
         operands=operands,
@@ -131,7 +131,7 @@ def mpi_send_xla_encode_gpu(ctx, x, token, dest, tag, comm):
         dtype_handle,
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_send",
         result_types=out_types,
         operands=operands,

--- a/mpi4jax/_src/collective_ops/sendrecv.py
+++ b/mpi4jax/_src/collective_ops/sendrecv.py
@@ -21,7 +21,7 @@ from ..utils import (
     get_default_layouts,
     effect,
 )
-from ..jax_compat import hlo_custom_call, token_type, ShapedArray
+from ..jax_compat import custom_call, token_type, ShapedArray
 from ..decorators import translation_rule_cpu, translation_rule_gpu
 from ..validation import enforce_types
 from ..comm import get_default_comm
@@ -182,7 +182,7 @@ def mpi_sendrecv_xla_encode_cpu(
         token,
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_sendrecv",
         result_types=out_types,
         operands=operands,
@@ -265,7 +265,7 @@ def mpi_sendrecv_xla_encode_gpu(
         status_ptr,
     )
 
-    return hlo_custom_call(
+    return custom_call(
         b"mpi_sendrecv",
         out_types=out_types,
         operands=operands,

--- a/mpi4jax/_src/jax_compat.py
+++ b/mpi4jax/_src/jax_compat.py
@@ -47,12 +47,12 @@ def check_jax_version():
 
 # TODO: remove the other path once we require jax/lib > 0.4.16
 if versiontuple(jax.__version__) >= (0, 4, 16):
-    from jaxlib.hlo_helpers import custom_call as hlo_custom_call  # noqa: F401
+    from jax.interpreters.mlir import custom_call  # noqa: F401
 else:
     if versiontuple(jaxlib.__version__) >= (0, 4, 2):
-        from jaxlib.hlo_helpers import custom_call as _hlo_custom_call  # noqa: F401
+        from jaxlib.hlo_helpers import custom_call as _custom_call  # noqa: F401
     else:
-        from jaxlib.mhlo_helpers import custom_call as _hlo_custom_call  # noqa: F401
+        from jaxlib.mhlo_helpers import custom_call as _custom_call  # noqa: F401
 
     # Recent versions return a structure with a field 'results'. We mock it on
     # older versions
@@ -60,8 +60,8 @@ else:
 
     MockResult = namedtuple("MockResult", ["results"])
 
-    def hlo_custom_call(*args, result_types, **kwargs):
-        results = _hlo_custom_call(*args, out_types=result_types, **kwargs)
+    def custom_call(*args, result_types, **kwargs):
+        results = _custom_call(*args, out_types=result_types, **kwargs)
         # TODO: remove this path once we require jax>=0.4.10
         if versiontuple(jaxlib.__version__) < (0, 4, 10):
             if not isinstance(results, list):

--- a/mpi4jax/_src/utils.py
+++ b/mpi4jax/_src/utils.py
@@ -44,7 +44,7 @@ def get_default_layouts(operands, order="c"):
     elif order == "f":
         default_layout = lambda t: tuple(range(len(t.shape)))
     else:
-        raise ValueError("Unknown order: {}".format(order))
+        raise ValueError(f"Unknown order: {order}")
 
     for op in operands:
         if isinstance(op, (ir.Value)):
@@ -61,7 +61,7 @@ def get_default_layouts(operands, order="c"):
             layouts.append(())
 
         else:
-            raise ValueError("Unknown operand type: {}".format(type(op)))
+            raise ValueError(f"Unknown operand type: {type(op)}")
 
     return layouts
 
@@ -110,7 +110,7 @@ def to_dtype_handle(dtype):
     """
     dtype_name = _np.dtype(dtype).name
     if dtype_name not in MPI_TYPE_MAP:
-        raise RuntimeError("Unknown MPI type for dtype {}".format(dtype_name))
+        raise RuntimeError(f"Unknown MPI type for dtype {dtype_name}")
 
     mpi_type = getattr(_MPI, MPI_TYPE_MAP[dtype_name])
     return to_mpi_handle(mpi_type)

--- a/mpi4jax/_version.py
+++ b/mpi4jax/_version.py
@@ -1,4 +1,3 @@
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -101,7 +100,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
             return None, None
     else:
         if verbose:
-            print("unable to find command, tried %s" % (commands,))
+            print("unable to find command, tried {}".format(commands))
         return None, None
     stdout = process.communicate()[0].strip().decode()
     if process.returncode != 0:
@@ -145,7 +144,7 @@ def git_get_keywords(versionfile_abs):
     # _version.py.
     keywords = {}
     try:
-        with open(versionfile_abs, "r") as fobj:
+        with open(versionfile_abs) as fobj:
             for line in fobj:
                 if line.strip().startswith("git_refnames ="):
                     mo = re.search(r'=\s*"(.*)"', line)

--- a/mpi4jax/_version.py
+++ b/mpi4jax/_version.py
@@ -1,3 +1,4 @@
+
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -100,7 +101,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
             return None, None
     else:
         if verbose:
-            print("unable to find command, tried {}".format(commands))
+            print("unable to find command, tried %s" % (commands,))
         return None, None
     stdout = process.communicate()[0].strip().decode()
     if process.returncode != 0:
@@ -144,7 +145,7 @@ def git_get_keywords(versionfile_abs):
     # _version.py.
     keywords = {}
     try:
-        with open(versionfile_abs) as fobj:
+        with open(versionfile_abs, "r") as fobj:
             for line in fobj:
                 if line.strip().startswith("git_refnames ="):
                     mo = re.search(r'=\s*"(.*)"', line)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ omit = [
 
 [tool.black]
 line-length = 88
-target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
+target-version = ['py38', 'py39', 'py310', 'py311']
 include = '\.pyi?$'
 exclude = '''
 (

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ else:
 ##############
 # Requirements
 
-JAX_MINIMUM_VERSION = "0.4.4"
+JAX_MINIMUM_VERSION = "0.4.5"
 
 BASE_DEPENDENCIES = ["mpi4py>=3.0.1", "numpy", f"jax>={JAX_MINIMUM_VERSION}"]
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ else:
 ##############
 # Requirements
 
-JAX_MINIMUM_VERSION = "0.4.0"
+JAX_MINIMUM_VERSION = "0.4.4"
 
 BASE_DEPENDENCIES = ["mpi4py>=3.0.1", "numpy", f"jax>={JAX_MINIMUM_VERSION}"]
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ else:
 ##############
 # Requirements
 
-JAX_MINIMUM_VERSION = "0.3.25"
+JAX_MINIMUM_VERSION = "0.4.0"
 
 BASE_DEPENDENCIES = ["mpi4py>=3.0.1", "numpy", f"jax>={JAX_MINIMUM_VERSION}"]
 
@@ -227,7 +227,7 @@ setup(
     ],
     packages=find_packages(),
     ext_modules=get_extensions(),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=BASE_DEPENDENCIES,
     extras_require={
         "dev": DEV_DEPENDENCIES,

--- a/tests/collective_ops/test_barrier.py
+++ b/tests/collective_ops/test_barrier.py
@@ -45,7 +45,7 @@ def test_barrier(capsys):
 
     time.sleep(size * 0.2)
 
-    with open(write_to, "r") as f:
+    with open(write_to) as f:
         outputs = f.readlines()
 
     assert len(outputs) == size * 2

--- a/tests/collective_ops/test_common.py
+++ b/tests/collective_ops/test_common.py
@@ -47,11 +47,10 @@ def run_in_subprocess(code, test_file, timeout=10):
 
     proc = subprocess.run(
         [sys.executable, test_file],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         bufsize=0,
         timeout=timeout,
-        universal_newlines=True,
+        text=True,
         env=env,
     )
     return proc

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,4 +1,3 @@
-
 # Version: 0.23
 
 """The Versioneer - like a rocketeer, but for versions.
@@ -342,7 +341,7 @@ def get_config_from_root(root):
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
     parser = configparser.ConfigParser()
-    with open(setup_cfg, "r") as cfg_file:
+    with open(setup_cfg) as cfg_file:
         parser.read_file(cfg_file)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
@@ -412,7 +411,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
             return None, None
     else:
         if verbose:
-            print("unable to find command, tried %s" % (commands,))
+            print("unable to find command, tried {}".format(commands))
         return None, None
     stdout = process.communicate()[0].strip().decode()
     if process.returncode != 0:
@@ -1092,7 +1091,7 @@ def git_get_keywords(versionfile_abs):
     # _version.py.
     keywords = {}
     try:
-        with open(versionfile_abs, "r") as fobj:
+        with open(versionfile_abs) as fobj:
             for line in fobj:
                 if line.strip().startswith("git_refnames ="):
                     mo = re.search(r'=\s*"(.*)"', line)
@@ -1330,7 +1329,7 @@ def do_vcs_install(versionfile_source, ipy):
     files.append(versioneer_file)
     present = False
     try:
-        with open(".gitattributes", "r") as fobj:
+        with open(".gitattributes") as fobj:
             for line in fobj:
                 if line.strip().startswith(versionfile_source):
                     if "export-subst" in line.strip().split()[1:]:
@@ -1412,7 +1411,7 @@ def write_to_version_file(filename, versions):
     with open(filename, "w") as f:
         f.write(SHORT_VERSION_PY % contents)
 
-    print("set %s to '%s'" % (filename, versions["version"]))
+    print("set {} to '{}'".format(filename, versions["version"]))
 
 
 def plus_or_dot(pieces):
@@ -1712,7 +1711,7 @@ def get_versions(verbose=False):
     try:
         ver = versions_from_file(versionfile_abs)
         if verbose:
-            print("got version from file %s %s" % (versionfile_abs, ver))
+            print("got version from file {} {}".format(versionfile_abs, ver))
         return ver
     except NotThisMethod:
         pass
@@ -2073,7 +2072,7 @@ def do_setup():
                        "__init__.py")
     if os.path.exists(ipy):
         try:
-            with open(ipy, "r") as f:
+            with open(ipy) as f:
                 old = f.read()
         except OSError:
             old = ""
@@ -2105,7 +2104,7 @@ def scan_setup_py():
     found = set()
     setters = False
     errors = 0
-    with open("setup.py", "r") as f:
+    with open("setup.py") as f:
         for line in f.readlines():
             if "import versioneer" in line:
                 found.add("import")

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,3 +1,4 @@
+
 # Version: 0.23
 
 """The Versioneer - like a rocketeer, but for versions.
@@ -341,7 +342,7 @@ def get_config_from_root(root):
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
     parser = configparser.ConfigParser()
-    with open(setup_cfg) as cfg_file:
+    with open(setup_cfg, "r") as cfg_file:
         parser.read_file(cfg_file)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
@@ -411,7 +412,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
             return None, None
     else:
         if verbose:
-            print("unable to find command, tried {}".format(commands))
+            print("unable to find command, tried %s" % (commands,))
         return None, None
     stdout = process.communicate()[0].strip().decode()
     if process.returncode != 0:
@@ -1091,7 +1092,7 @@ def git_get_keywords(versionfile_abs):
     # _version.py.
     keywords = {}
     try:
-        with open(versionfile_abs) as fobj:
+        with open(versionfile_abs, "r") as fobj:
             for line in fobj:
                 if line.strip().startswith("git_refnames ="):
                     mo = re.search(r'=\s*"(.*)"', line)
@@ -1329,7 +1330,7 @@ def do_vcs_install(versionfile_source, ipy):
     files.append(versioneer_file)
     present = False
     try:
-        with open(".gitattributes") as fobj:
+        with open(".gitattributes", "r") as fobj:
             for line in fobj:
                 if line.strip().startswith(versionfile_source):
                     if "export-subst" in line.strip().split()[1:]:
@@ -1411,7 +1412,7 @@ def write_to_version_file(filename, versions):
     with open(filename, "w") as f:
         f.write(SHORT_VERSION_PY % contents)
 
-    print("set {} to '{}'".format(filename, versions["version"]))
+    print("set %s to '%s'" % (filename, versions["version"]))
 
 
 def plus_or_dot(pieces):
@@ -1711,7 +1712,7 @@ def get_versions(verbose=False):
     try:
         ver = versions_from_file(versionfile_abs)
         if verbose:
-            print("got version from file {} {}".format(versionfile_abs, ver))
+            print("got version from file %s %s" % (versionfile_abs, ver))
         return ver
     except NotThisMethod:
         pass
@@ -2072,7 +2073,7 @@ def do_setup():
                        "__init__.py")
     if os.path.exists(ipy):
         try:
-            with open(ipy) as f:
+            with open(ipy, "r") as f:
                 old = f.read()
         except OSError:
             old = ""
@@ -2104,7 +2105,7 @@ def scan_setup_py():
     found = set()
     setters = False
     errors = 0
-    with open("setup.py") as f:
+    with open("setup.py", "r") as f:
         for line in f.readlines():
             if "import versioneer" in line:
                 found.add("import")


### PR DESCRIPTION
Following guidance from https://github.com/google/jax/pull/17880/files 

also rename it to custom_call from hlo custom call, as it has long not been named like that.