### PR TITLE
Rename gpu -> cuda where relevant

### DIFF
--- a/.github/workflows/build-cuda-ext.yml
+++ b/.github/workflows/build-cuda-ext.yml
@@ -1,4 +1,4 @@
-name: Build GPU extensions
+name: Build CUDA extensions
 
 on:
   pull_request:
@@ -73,4 +73,4 @@ jobs:
     - name: Build GPU extensions
       run: |
         python setup.py build_ext --inplace
-        test -f mpi4jax/_src/xla_bridge/mpi_xla_bridge_gpu*.so
+        test -f mpi4jax/_src/xla_bridge/mpi_xla_bridge_cuda*.so

--- a/mpi4jax/_src/collective_ops/allgather.py
+++ b/mpi4jax/_src/collective_ops/allgather.py
@@ -23,7 +23,7 @@ from ..utils import (
 from ..jax_compat import custom_call, token_type, ShapedArray
 from ..decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from ..validation import enforce_types
@@ -181,7 +181,7 @@ def mpi_allgather_xla_encode_device(ctx, sendbuf, token, comm):
 
 
 mpi_allgather_xla_encode_xpu = translation_rule_xpu(mpi_allgather_xla_encode_device)
-mpi_allgather_xla_encode_gpu = translation_rule_gpu(mpi_allgather_xla_encode_device)
+mpi_allgather_xla_encode_cuda = translation_rule_cuda(mpi_allgather_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -200,5 +200,5 @@ mpi_allgather_p.def_impl(mpi_allgather_impl)
 mpi_allgather_p.def_effectful_abstract_eval(mpi_allgather_abstract_eval)
 
 mlir.register_lowering(mpi_allgather_p, mpi_allgather_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_allgather_p, mpi_allgather_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_allgather_p, mpi_allgather_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_allgather_p, mpi_allgather_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/_src/collective_ops/allreduce.py
+++ b/mpi4jax/_src/collective_ops/allreduce.py
@@ -24,7 +24,7 @@ from ..utils import (
 from ..jax_compat import custom_call, token_type, ShapedArray
 from ..decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from ..validation import enforce_types
@@ -173,7 +173,7 @@ def mpi_allreduce_xla_encode_device(ctx, x, token, op, comm, transpose):
     ).results
 
 
-mpi_allreduce_xla_encode_gpu = translation_rule_gpu(mpi_allreduce_xla_encode_device)
+mpi_allreduce_xla_encode_cuda = translation_rule_cuda(mpi_allreduce_xla_encode_device)
 mpi_allreduce_xla_encode_xpu = translation_rule_xpu(mpi_allreduce_xla_encode_device)
 
 
@@ -235,5 +235,5 @@ ad.primitive_transposes[mpi_allreduce_p] = mpi_allreduce_transpose_rule
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_allreduce_p, mpi_allreduce_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_allreduce_p, mpi_allreduce_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_allreduce_p, mpi_allreduce_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_allreduce_p, mpi_allreduce_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/_src/collective_ops/alltoall.py
+++ b/mpi4jax/_src/collective_ops/alltoall.py
@@ -23,7 +23,7 @@ from ..utils import (
 from ..jax_compat import custom_call, token_type, ShapedArray
 from ..decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from ..validation import enforce_types
@@ -182,7 +182,7 @@ def mpi_alltoall_xla_encode_device(ctx, x, token, comm):
 
 
 mpi_alltoall_xla_encode_xpu = translation_rule_xpu(mpi_alltoall_xla_encode_device)
-mpi_alltoall_xla_encode_gpu = translation_rule_gpu(mpi_alltoall_xla_encode_device)
+mpi_alltoall_xla_encode_cuda = translation_rule_cuda(mpi_alltoall_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -199,5 +199,5 @@ mpi_alltoall_p.def_effectful_abstract_eval(mpi_alltoall_abstract_eval)
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_alltoall_p, mpi_alltoall_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_alltoall_p, mpi_alltoall_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_alltoall_p, mpi_alltoall_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_alltoall_p, mpi_alltoall_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/_src/collective_ops/barrier.py
+++ b/mpi4jax/_src/collective_ops/barrier.py
@@ -22,7 +22,7 @@ from ..utils import (
 from ..jax_compat import custom_call, token_type
 from ..decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from ..validation import enforce_types
@@ -115,7 +115,7 @@ def mpi_barrier_xla_encode_device(ctx, token, comm):
 
 
 mpi_barrier_xla_encode_xpu = translation_rule_xpu(mpi_barrier_xla_encode_device)
-mpi_barrier_xla_encode_gpu = translation_rule_gpu(mpi_barrier_xla_encode_device)
+mpi_barrier_xla_encode_cuda = translation_rule_cuda(mpi_barrier_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -136,5 +136,5 @@ batching.primitive_batchers[mpi_barrier_p] = mpi_barrier_batch_eval
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_barrier_p, mpi_barrier_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_barrier_p, mpi_barrier_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_barrier_p, mpi_barrier_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_barrier_p, mpi_barrier_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/_src/collective_ops/bcast.py
+++ b/mpi4jax/_src/collective_ops/bcast.py
@@ -23,7 +23,7 @@ from ..utils import (
 from ..jax_compat import custom_call, token_type, ShapedArray
 from ..decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from ..validation import enforce_types
@@ -179,7 +179,7 @@ def mpi_bcast_xla_encode_device(ctx, x, token, root, comm):
 
 
 mpi_bcast_xla_encode_xpu = translation_rule_xpu(mpi_bcast_xla_encode_device)
-mpi_bcast_xla_encode_gpu = translation_rule_gpu(mpi_bcast_xla_encode_device)
+mpi_bcast_xla_encode_cuda = translation_rule_cuda(mpi_bcast_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -204,5 +204,5 @@ mpi_bcast_p.def_effectful_abstract_eval(mpi_bcast_abstract_eval)
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_bcast_p, mpi_bcast_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_bcast_p, mpi_bcast_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_bcast_p, mpi_bcast_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_bcast_p, mpi_bcast_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/_src/collective_ops/gather.py
+++ b/mpi4jax/_src/collective_ops/gather.py
@@ -23,7 +23,7 @@ from ..utils import (
 from ..jax_compat import custom_call, token_type, ShapedArray
 from ..decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from ..validation import enforce_types
@@ -212,7 +212,7 @@ def mpi_gather_xla_encode_device(ctx, x, token, root, comm):
 
 
 mpi_gather_xla_encode_xpu = translation_rule_xpu(mpi_gather_xla_encode_device)
-mpi_gather_xla_encode_gpu = translation_rule_gpu(mpi_gather_xla_encode_device)
+mpi_gather_xla_encode_cuda = translation_rule_cuda(mpi_gather_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -238,5 +238,5 @@ mpi_gather_p.def_effectful_abstract_eval(mpi_gather_abstract_eval)
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_gather_p, mpi_gather_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_gather_p, mpi_gather_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_gather_p, mpi_gather_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_gather_p, mpi_gather_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/_src/collective_ops/recv.py
+++ b/mpi4jax/_src/collective_ops/recv.py
@@ -24,7 +24,7 @@ from ..utils import (
 from ..jax_compat import custom_call, token_type, ShapedArray
 from ..decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from ..validation import enforce_types
@@ -197,7 +197,7 @@ def mpi_recv_xla_encode_device(ctx, x, token, source, tag, comm, status):
 
 
 mpi_recv_xla_encode_xpu = translation_rule_xpu(mpi_recv_xla_encode_device)
-mpi_recv_xla_encode_gpu = translation_rule_gpu(mpi_recv_xla_encode_device)
+mpi_recv_xla_encode_cuda = translation_rule_cuda(mpi_recv_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -214,5 +214,5 @@ mpi_recv_p.def_effectful_abstract_eval(mpi_recv_abstract_eval)
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_recv_p, mpi_recv_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_recv_p, mpi_recv_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_recv_p, mpi_recv_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_recv_p, mpi_recv_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/_src/collective_ops/reduce.py
+++ b/mpi4jax/_src/collective_ops/reduce.py
@@ -23,7 +23,7 @@ from ..utils import (
 from ..jax_compat import custom_call, token_type, ShapedArray
 from ..decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from ..validation import enforce_types
@@ -186,7 +186,7 @@ def mpi_reduce_xla_encode_device(ctx, x, token, op, root, comm):
 
 
 mpi_reduce_xla_encode_xpu = translation_rule_xpu(mpi_reduce_xla_encode_device)
-mpi_reduce_xla_encode_gpu = translation_rule_gpu(mpi_reduce_xla_encode_device)
+mpi_reduce_xla_encode_cuda = translation_rule_cuda(mpi_reduce_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -211,5 +211,5 @@ mpi_reduce_p.def_effectful_abstract_eval(mpi_reduce_abstract_eval)
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_reduce_p, mpi_reduce_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_reduce_p, mpi_reduce_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_reduce_p, mpi_reduce_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_reduce_p, mpi_reduce_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/_src/collective_ops/scan.py
+++ b/mpi4jax/_src/collective_ops/scan.py
@@ -23,7 +23,7 @@ from ..utils import (
 from ..jax_compat import custom_call, token_type, ShapedArray
 from ..decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from ..validation import enforce_types
@@ -162,7 +162,7 @@ def mpi_scan_xla_encode_device(ctx, x, token, op, comm):
 
 
 mpi_scan_xla_encode_xpu = translation_rule_xpu(mpi_scan_xla_encode_device)
-mpi_scan_xla_encode_gpu = translation_rule_gpu(mpi_scan_xla_encode_device)
+mpi_scan_xla_encode_cuda = translation_rule_cuda(mpi_scan_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -179,5 +179,5 @@ mpi_scan_p.def_effectful_abstract_eval(mpi_scan_abstract_eval)
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_scan_p, mpi_scan_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_scan_p, mpi_scan_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_scan_p, mpi_scan_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_scan_p, mpi_scan_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/_src/collective_ops/scatter.py
+++ b/mpi4jax/_src/collective_ops/scatter.py
@@ -23,7 +23,7 @@ from ..utils import (
 from ..jax_compat import custom_call, token_type, ShapedArray
 from ..decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from ..validation import enforce_types
@@ -204,7 +204,7 @@ def mpi_scatter_xla_encode_device(ctx, x, token, root, comm):
 
 
 mpi_scatter_xla_encode_xpu = translation_rule_xpu(mpi_scatter_xla_encode_device)
-mpi_scatter_xla_encode_gpu = translation_rule_gpu(mpi_scatter_xla_encode_device)
+mpi_scatter_xla_encode_cuda = translation_rule_cuda(mpi_scatter_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -228,5 +228,5 @@ mpi_scatter_p.def_effectful_abstract_eval(mpi_scatter_abstract_eval)
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_scatter_p, mpi_scatter_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_scatter_p, mpi_scatter_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_scatter_p, mpi_scatter_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_scatter_p, mpi_scatter_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/_src/collective_ops/send.py
+++ b/mpi4jax/_src/collective_ops/send.py
@@ -23,7 +23,7 @@ from ..utils import (
 from ..jax_compat import custom_call, token_type
 from ..decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from ..validation import enforce_types
@@ -152,7 +152,7 @@ def mpi_send_xla_encode_device(ctx, x, token, dest, tag, comm):
 
 
 mpi_send_xla_encode_xpu = translation_rule_xpu(mpi_send_xla_encode_device)
-mpi_send_xla_encode_gpu = translation_rule_gpu(mpi_send_xla_encode_device)
+mpi_send_xla_encode_cuda = translation_rule_cuda(mpi_send_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -165,5 +165,5 @@ mpi_send_p.def_effectful_abstract_eval(mpi_send_abstract_eval)
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_send_p, mpi_send_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_send_p, mpi_send_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_send_p, mpi_send_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_send_p, mpi_send_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/_src/collective_ops/sendrecv.py
+++ b/mpi4jax/_src/collective_ops/sendrecv.py
@@ -25,7 +25,7 @@ from ..utils import (
 from ..jax_compat import custom_call, token_type, ShapedArray
 from ..decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from ..validation import enforce_types
@@ -326,8 +326,8 @@ def mpi_sendrecv_xla_encode_xpu(
     )
 
 
-@translation_rule_gpu
-def mpi_sendrecv_xla_encode_gpu(
+@translation_rule_cuda
+def mpi_sendrecv_xla_encode_cuda(
     ctx,
     sendbuf,
     recvbuf,
@@ -481,5 +481,5 @@ ad.primitive_transposes[mpi_sendrecv_p] = mpi_sendrecv_transpose_rule
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_sendrecv_p, mpi_sendrecv_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_sendrecv_p, mpi_sendrecv_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_sendrecv_p, mpi_sendrecv_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_sendrecv_p, mpi_sendrecv_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/_src/decorators.py
+++ b/mpi4jax/_src/decorators.py
@@ -7,10 +7,10 @@ _cuda_mpi_setup_done = False
 _sycl_mpi_setup_done = False
 
 
-def ensure_gpu_ext():
-    from .xla_bridge import HAS_GPU_EXT
+def ensure_cuda_ext():
+    from .xla_bridge import HAS_CUDA_EXT
 
-    if not HAS_GPU_EXT:
+    if not HAS_CUDA_EXT:
         raise ImportError(
             "The mpi4jax GPU extensions could not be imported. "
             "Please re-build mpi4jax with CUDA support and try again."
@@ -43,11 +43,11 @@ def setup_cuda_mpi():
 
     _cuda_mpi_setup_done = True
 
-    gpu_copy_behavior = os.getenv("MPI4JAX_USE_CUDA_MPI", "")
+    cuda_copy_behavior = os.getenv("MPI4JAX_USE_CUDA_MPI", "")
 
-    if _is_truthy(gpu_copy_behavior):
+    if _is_truthy(cuda_copy_behavior):
         has_cuda_mpi = True
-    elif _is_falsy(gpu_copy_behavior):
+    elif _is_falsy(cuda_copy_behavior):
         has_cuda_mpi = False
     else:
         has_cuda_mpi = False
@@ -59,9 +59,9 @@ def setup_cuda_mpi():
         )
         warnings.warn(warn_msg)
 
-    from .xla_bridge import mpi_xla_bridge_gpu
+    from .xla_bridge import mpi_xla_bridge_cuda
 
-    mpi_xla_bridge_gpu.set_copy_to_host(not has_cuda_mpi)
+    mpi_xla_bridge_cuda.set_copy_to_host(not has_cuda_mpi)
 
 
 def setup_sycl_mpi():
@@ -112,14 +112,14 @@ def translation_rule_cpu(func):
     return wrapped
 
 
-def translation_rule_gpu(func):
+def translation_rule_cuda(func):
     """XLA primitive translation rule on GPU for mpi4jax custom calls.
 
     This runs generic setup and boilerplate functions.
     """
     # functions to call before running the translation rule
     setup_funcs = (
-        ensure_gpu_ext,
+        ensure_cuda_ext,
         setup_cuda_mpi,
     )
 

--- a/mpi4jax/_src/utils.py
+++ b/mpi4jax/_src/utils.py
@@ -161,7 +161,7 @@ def has_cuda_support() -> bool:
     """
     from . import xla_bridge
 
-    return xla_bridge.HAS_GPU_EXT
+    return xla_bridge.HAS_CUDA_EXT
 
 
 def has_sycl_support() -> bool:

--- a/mpi4jax/_src/xla_bridge/__init__.py
+++ b/mpi4jax/_src/xla_bridge/__init__.py
@@ -5,11 +5,11 @@ from . import mpi_xla_bridge
 from . import mpi_xla_bridge_cpu
 
 try:
-    from . import mpi_xla_bridge_gpu
+    from . import mpi_xla_bridge_cuda
 except ImportError:
-    HAS_GPU_EXT = False
+    HAS_CUDA_EXT = False
 else:
-    HAS_GPU_EXT = True
+    HAS_CUDA_EXT = True
 
 try:
     from . import mpi_xla_bridge_xpu
@@ -29,13 +29,13 @@ mpi_xla_bridge.set_logging(_is_truthy(os.getenv("MPI4JAX_DEBUG", "")))
 
 
 # register custom call targets
-for name, fn in mpi_xla_bridge_cpu.cpu_custom_call_targets.items():
+for name, fn in mpi_xla_bridge_cpu.custom_call_targets.items():
     xla_client.register_custom_call_target(name, fn, platform="cpu")
 
-if HAS_GPU_EXT:
-    for name, fn in mpi_xla_bridge_gpu.gpu_custom_call_targets.items():
+if HAS_CUDA_EXT:
+    for name, fn in mpi_xla_bridge_cuda.custom_call_targets.items():
         xla_client.register_custom_call_target(name, fn, platform="CUDA")
 
 if HAS_XPU_EXT:
-    for name, fn in mpi_xla_bridge_xpu.xpu_custom_call_targets.items():
+    for name, fn in mpi_xla_bridge_xpu.custom_call_targets.items():
         xla_client.register_custom_call_target(name, fn, platform="SYCL")

--- a/mpi4jax/_src/xla_bridge/mpi_xla_bridge_cpu.pyx
+++ b/mpi4jax/_src/xla_bridge/mpi_xla_bridge_cpu.pyx
@@ -13,6 +13,15 @@ from mpi4py.libmpi cimport (
 
 from . cimport mpi_xla_bridge
 
+# The XLA_BRIDGE extension will register with xla
+# all capsules stored in here. So all custom calls declared in this
+# file should be registered in this dictionary.
+custom_call_targets = {}
+
+cdef declare_custom_call_target(fn_name, void* fn):
+    cdef const char* name = "xla._CUSTOM_CALL_TARGET"
+    custom_call_targets[fn_name] = PyCapsule_New(fn, name, NULL)
+
 
 #
 # CPU XLA targets
@@ -189,21 +198,15 @@ cdef void mpi_sendrecv_cpu(void** out_ptr, void** data_ptr) nogil:
     )
 
 
-cpu_custom_call_targets = {}
-
-cdef register_custom_call_target(fn_name, void* fn):
-    cdef const char* name = "xla._CUSTOM_CALL_TARGET"
-    cpu_custom_call_targets[fn_name] = PyCapsule_New(fn, name, NULL)
-
-register_custom_call_target(b"mpi_allgather", <void*>(mpi_allgather_cpu))
-register_custom_call_target(b"mpi_allreduce", <void*>(mpi_allreduce_cpu))
-register_custom_call_target(b"mpi_alltoall", <void*>(mpi_alltoall_cpu))
-register_custom_call_target(b"mpi_barrier", <void*>(mpi_barrier_cpu))
-register_custom_call_target(b"mpi_bcast", <void*>(mpi_bcast_cpu))
-register_custom_call_target(b"mpi_gather", <void*>(mpi_gather_cpu))
-register_custom_call_target(b"mpi_recv", <void*>(mpi_recv_cpu))
-register_custom_call_target(b"mpi_reduce", <void*>(mpi_reduce_cpu))
-register_custom_call_target(b"mpi_scan", <void*>(mpi_scan_cpu))
-register_custom_call_target(b"mpi_scatter", <void*>(mpi_scatter_cpu))
-register_custom_call_target(b"mpi_send", <void*>(mpi_send_cpu))
-register_custom_call_target(b"mpi_sendrecv", <void*>(mpi_sendrecv_cpu))
+declare_custom_call_target(b"mpi_allgather", <void*>(mpi_allgather_cpu))
+declare_custom_call_target(b"mpi_allreduce", <void*>(mpi_allreduce_cpu))
+declare_custom_call_target(b"mpi_alltoall", <void*>(mpi_alltoall_cpu))
+declare_custom_call_target(b"mpi_barrier", <void*>(mpi_barrier_cpu))
+declare_custom_call_target(b"mpi_bcast", <void*>(mpi_bcast_cpu))
+declare_custom_call_target(b"mpi_gather", <void*>(mpi_gather_cpu))
+declare_custom_call_target(b"mpi_recv", <void*>(mpi_recv_cpu))
+declare_custom_call_target(b"mpi_reduce", <void*>(mpi_reduce_cpu))
+declare_custom_call_target(b"mpi_scan", <void*>(mpi_scan_cpu))
+declare_custom_call_target(b"mpi_scatter", <void*>(mpi_scatter_cpu))
+declare_custom_call_target(b"mpi_send", <void*>(mpi_send_cpu))
+declare_custom_call_target(b"mpi_sendrecv", <void*>(mpi_sendrecv_cpu))

--- a/mpi4jax/_src/xla_bridge/mpi_xla_bridge_xpu.pyx
+++ b/mpi4jax/_src/xla_bridge/mpi_xla_bridge_xpu.pyx
@@ -38,6 +38,16 @@ from .sycl_runtime_api cimport (
 from . cimport mpi_xla_bridge
 
 
+# The XLA_BRIDGE extension will register with xla
+# all capsules stored in here. So all custom calls declared in this
+# file should be registered in this dictionary.
+custom_call_targets = {}
+
+cdef declare_custom_call_target(fn_name, void* fn):
+    cdef const char* name = "xla._CUSTOM_CALL_TARGET"
+    custom_call_targets[fn_name] = PyCapsule_New(fn, name, NULL)
+
+
 # Config
 
 cdef bint COPY_TO_HOST = False
@@ -692,23 +702,15 @@ cdef void mpi_sendrecv_xpu(void* stream, void** buffers,
             checked_sycl_memcpy(xqueue, out_buf, recvbuf , bytes_recv, comm)
         free(recvbuf)
 
-
-xpu_custom_call_targets = {}
-
-cdef register_custom_call_target(fn_name, void* fn):
-    cdef const char* name = "xla._CUSTOM_CALL_TARGET"
-    xpu_custom_call_targets[fn_name] = PyCapsule_New(fn, name, NULL)
-
-
-register_custom_call_target(b"mpi_allgather", <void*>(mpi_allgather_xpu))
-register_custom_call_target(b"mpi_allreduce", <void*>(mpi_allreduce_xpu))
-register_custom_call_target(b"mpi_alltoall", <void*>(mpi_alltoall_xpu))
-register_custom_call_target(b"mpi_barrier", <void*>(mpi_barrier_xpu))
-register_custom_call_target(b"mpi_bcast", <void*>(mpi_bcast_xpu))
-register_custom_call_target(b"mpi_gather", <void*>(mpi_gather_xpu))
-register_custom_call_target(b"mpi_recv", <void*>(mpi_recv_xpu))
-register_custom_call_target(b"mpi_reduce", <void*>(mpi_reduce_xpu))
-register_custom_call_target(b"mpi_scan", <void*>(mpi_scan_xpu))
-register_custom_call_target(b"mpi_scatter", <void*>(mpi_scatter_xpu))
-register_custom_call_target(b"mpi_send", <void*>(mpi_send_xpu))
-register_custom_call_target(b"mpi_sendrecv", <void*>(mpi_sendrecv_xpu))
+declare_custom_call_target(b"mpi_allgather", <void*>(mpi_allgather_xpu))
+declare_custom_call_target(b"mpi_allreduce", <void*>(mpi_allreduce_xpu))
+declare_custom_call_target(b"mpi_alltoall", <void*>(mpi_alltoall_xpu))
+declare_custom_call_target(b"mpi_barrier", <void*>(mpi_barrier_xpu))
+declare_custom_call_target(b"mpi_bcast", <void*>(mpi_bcast_xpu))
+declare_custom_call_target(b"mpi_gather", <void*>(mpi_gather_xpu))
+declare_custom_call_target(b"mpi_recv", <void*>(mpi_recv_xpu))
+declare_custom_call_target(b"mpi_reduce", <void*>(mpi_reduce_xpu))
+declare_custom_call_target(b"mpi_scan", <void*>(mpi_scan_xpu))
+declare_custom_call_target(b"mpi_scatter", <void*>(mpi_scatter_xpu))
+declare_custom_call_target(b"mpi_send", <void*>(mpi_send_xpu))
+declare_custom_call_target(b"mpi_sendrecv", <void*>(mpi_sendrecv_xpu))

--- a/mpi4jax/experimental/notoken/collective_ops/allgather.py
+++ b/mpi4jax/experimental/notoken/collective_ops/allgather.py
@@ -20,7 +20,7 @@ from mpi4jax._src.utils import (
 from mpi4jax._src.jax_compat import custom_call, token_type, ShapedArray
 from mpi4jax._src.decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from mpi4jax._src.validation import enforce_types
@@ -177,7 +177,7 @@ def mpi_allgather_xla_encode_device(ctx, sendbuf, comm):
 
 
 mpi_allgather_xla_encode_xpu = translation_rule_xpu(mpi_allgather_xla_encode_device)
-mpi_allgather_xla_encode_gpu = translation_rule_gpu(mpi_allgather_xla_encode_device)
+mpi_allgather_xla_encode_cuda = translation_rule_cuda(mpi_allgather_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -192,5 +192,5 @@ mpi_allgather_p.def_impl(mpi_allgather_impl)
 mpi_allgather_p.def_effectful_abstract_eval(mpi_allgather_abstract_eval)
 
 mlir.register_lowering(mpi_allgather_p, mpi_allgather_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_allgather_p, mpi_allgather_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_allgather_p, mpi_allgather_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_allgather_p, mpi_allgather_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/allreduce.py
+++ b/mpi4jax/experimental/notoken/collective_ops/allreduce.py
@@ -22,7 +22,7 @@ from mpi4jax._src.utils import (
 from mpi4jax._src.jax_compat import custom_call, token_type, ShapedArray
 from mpi4jax._src.decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from mpi4jax._src.validation import enforce_types
@@ -180,7 +180,7 @@ def mpi_allreduce_xla_encode_device(ctx, x, token, op, comm, transpose):
 
 
 mpi_allreduce_xla_encode_xpu = translation_rule_xpu(mpi_allreduce_xla_encode_device)
-mpi_allreduce_xla_encode_gpu = translation_rule_gpu(mpi_allreduce_xla_encode_device)
+mpi_allreduce_xla_encode_cuda = translation_rule_cuda(mpi_allreduce_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -236,5 +236,5 @@ ad.primitive_transposes[mpi_allreduce_p] = mpi_allreduce_transpose_rule
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_allreduce_p, mpi_allreduce_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_allreduce_p, mpi_allreduce_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_allreduce_p, mpi_allreduce_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_allreduce_p, mpi_allreduce_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/alltoall.py
+++ b/mpi4jax/experimental/notoken/collective_ops/alltoall.py
@@ -20,7 +20,7 @@ from mpi4jax._src.utils import (
 from mpi4jax._src.jax_compat import custom_call, token_type, ShapedArray
 from mpi4jax._src.decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from mpi4jax._src.validation import enforce_types
@@ -179,7 +179,7 @@ def mpi_alltoall_xla_encode_device(ctx, x, comm):
 
 
 mpi_alltoall_xla_encode_xpu = translation_rule_xpu(mpi_alltoall_xla_encode_device)
-mpi_alltoall_xla_encode_gpu = translation_rule_gpu(mpi_alltoall_xla_encode_device)
+mpi_alltoall_xla_encode_cuda = translation_rule_cuda(mpi_alltoall_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -192,5 +192,5 @@ mpi_alltoall_p.def_effectful_abstract_eval(mpi_alltoall_abstract_eval)
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_alltoall_p, mpi_alltoall_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_alltoall_p, mpi_alltoall_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_alltoall_p, mpi_alltoall_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_alltoall_p, mpi_alltoall_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/barrier.py
+++ b/mpi4jax/experimental/notoken/collective_ops/barrier.py
@@ -17,7 +17,7 @@ from mpi4jax._src.utils import (
 from mpi4jax._src.jax_compat import custom_call, token_type
 from mpi4jax._src.decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from mpi4jax._src.validation import enforce_types
@@ -111,7 +111,7 @@ def mpi_barrier_xla_encode_device(ctx, comm):
 
 
 mpi_barrier_xla_encode_xpu = translation_rule_xpu(mpi_barrier_xla_encode_device)
-mpi_barrier_xla_encode_gpu = translation_rule_gpu(mpi_barrier_xla_encode_device)
+mpi_barrier_xla_encode_cuda = translation_rule_cuda(mpi_barrier_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -132,5 +132,5 @@ batching.primitive_batchers[mpi_barrier_p] = mpi_barrier_batch_eval
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_barrier_p, mpi_barrier_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_barrier_p, mpi_barrier_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_barrier_p, mpi_barrier_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_barrier_p, mpi_barrier_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/bcast.py
+++ b/mpi4jax/experimental/notoken/collective_ops/bcast.py
@@ -20,7 +20,7 @@ from mpi4jax._src.utils import (
 from mpi4jax._src.jax_compat import custom_call, token_type, ShapedArray
 from mpi4jax._src.decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from mpi4jax._src.validation import enforce_types
@@ -180,7 +180,7 @@ def mpi_bcast_xla_encode_device(ctx, x, root, comm):
 
 
 mpi_bcast_xla_encode_xpu = translation_rule_xpu(mpi_bcast_xla_encode_device)
-mpi_bcast_xla_encode_gpu = translation_rule_gpu(mpi_bcast_xla_encode_device)
+mpi_bcast_xla_encode_cuda = translation_rule_cuda(mpi_bcast_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -201,5 +201,5 @@ mpi_bcast_p.def_effectful_abstract_eval(mpi_bcast_abstract_eval)
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_bcast_p, mpi_bcast_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_bcast_p, mpi_bcast_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_bcast_p, mpi_bcast_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_bcast_p, mpi_bcast_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/gather.py
+++ b/mpi4jax/experimental/notoken/collective_ops/gather.py
@@ -20,7 +20,7 @@ from mpi4jax._src.utils import (
 from mpi4jax._src.jax_compat import custom_call, token_type, ShapedArray
 from mpi4jax._src.decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from mpi4jax._src.validation import enforce_types
@@ -210,7 +210,7 @@ def mpi_gather_xla_encode_device(ctx, x, root, comm):
 
 
 mpi_gather_xla_encode_xpu = translation_rule_xpu(mpi_gather_xla_encode_device)
-mpi_gather_xla_encode_gpu = translation_rule_gpu(mpi_gather_xla_encode_device)
+mpi_gather_xla_encode_cuda = translation_rule_cuda(mpi_gather_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -232,5 +232,5 @@ mpi_gather_p.def_effectful_abstract_eval(mpi_gather_abstract_eval)
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_gather_p, mpi_gather_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_gather_p, mpi_gather_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_gather_p, mpi_gather_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_gather_p, mpi_gather_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/recv.py
+++ b/mpi4jax/experimental/notoken/collective_ops/recv.py
@@ -21,7 +21,7 @@ from mpi4jax._src.utils import (
 from mpi4jax._src.jax_compat import custom_call, token_type, ShapedArray
 from mpi4jax._src.decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from mpi4jax._src.validation import enforce_types
@@ -194,7 +194,7 @@ def mpi_recv_xla_encode_device(ctx, x, source, tag, comm, status):
 
 
 mpi_recv_xla_encode_xpu = translation_rule_xpu(mpi_recv_xla_encode_device)
-mpi_recv_xla_encode_gpu = translation_rule_gpu(mpi_recv_xla_encode_device)
+mpi_recv_xla_encode_cuda = translation_rule_cuda(mpi_recv_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -207,5 +207,5 @@ mpi_recv_p.def_effectful_abstract_eval(mpi_recv_abstract_eval)
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_recv_p, mpi_recv_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_recv_p, mpi_recv_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_recv_p, mpi_recv_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_recv_p, mpi_recv_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/reduce.py
+++ b/mpi4jax/experimental/notoken/collective_ops/reduce.py
@@ -20,7 +20,7 @@ from mpi4jax._src.utils import (
 from mpi4jax._src.jax_compat import custom_call, token_type, ShapedArray
 from mpi4jax._src.decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from mpi4jax._src.validation import enforce_types
@@ -186,7 +186,7 @@ def mpi_reduce_xla_encode_device(ctx, x, op, root, comm):
 
 
 mpi_reduce_xla_encode_xpu = translation_rule_xpu(mpi_reduce_xla_encode_device)
-mpi_reduce_xla_encode_gpu = translation_rule_gpu(mpi_reduce_xla_encode_device)
+mpi_reduce_xla_encode_cuda = translation_rule_cuda(mpi_reduce_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -207,5 +207,5 @@ mpi_reduce_p.def_effectful_abstract_eval(mpi_reduce_abstract_eval)
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_reduce_p, mpi_reduce_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_reduce_p, mpi_reduce_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_reduce_p, mpi_reduce_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_reduce_p, mpi_reduce_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/scan.py
+++ b/mpi4jax/experimental/notoken/collective_ops/scan.py
@@ -20,7 +20,7 @@ from mpi4jax._src.utils import (
 from mpi4jax._src.jax_compat import custom_call, token_type, ShapedArray
 from mpi4jax._src.decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from mpi4jax._src.validation import enforce_types
@@ -162,7 +162,7 @@ def mpi_scan_xla_encode_device(ctx, x, op, comm):
 
 
 mpi_scan_xla_encode_xpu = translation_rule_xpu(mpi_scan_xla_encode_device)
-mpi_scan_xla_encode_gpu = translation_rule_gpu(mpi_scan_xla_encode_device)
+mpi_scan_xla_encode_cuda = translation_rule_cuda(mpi_scan_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -175,5 +175,5 @@ mpi_scan_p.def_effectful_abstract_eval(mpi_scan_abstract_eval)
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_scan_p, mpi_scan_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_scan_p, mpi_scan_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_scan_p, mpi_scan_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_scan_p, mpi_scan_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/scatter.py
+++ b/mpi4jax/experimental/notoken/collective_ops/scatter.py
@@ -20,7 +20,7 @@ from mpi4jax._src.utils import (
 from mpi4jax._src.jax_compat import custom_call, token_type, ShapedArray
 from mpi4jax._src.decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from mpi4jax._src.validation import enforce_types
@@ -202,7 +202,7 @@ def mpi_scatter_xla_encode_device(ctx, x, root, comm):
 
 
 mpi_scatter_xla_encode_xpu = translation_rule_xpu(mpi_scatter_xla_encode_device)
-mpi_scatter_xla_encode_gpu = translation_rule_gpu(mpi_scatter_xla_encode_device)
+mpi_scatter_xla_encode_cuda = translation_rule_cuda(mpi_scatter_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -222,5 +222,5 @@ mpi_scatter_p.def_effectful_abstract_eval(mpi_scatter_abstract_eval)
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_scatter_p, mpi_scatter_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_scatter_p, mpi_scatter_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_scatter_p, mpi_scatter_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_scatter_p, mpi_scatter_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/send.py
+++ b/mpi4jax/experimental/notoken/collective_ops/send.py
@@ -20,7 +20,7 @@ from mpi4jax._src.utils import (
 from mpi4jax._src.jax_compat import custom_call, token_type
 from mpi4jax._src.decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from mpi4jax._src.validation import enforce_types
@@ -156,7 +156,7 @@ def mpi_send_xla_encode_device(ctx, x, dest, tag, comm):
 
 
 mpi_send_xla_encode_xpu = translation_rule_xpu(mpi_send_xla_encode_device)
-mpi_send_xla_encode_gpu = translation_rule_gpu(mpi_send_xla_encode_device)
+mpi_send_xla_encode_cuda = translation_rule_cuda(mpi_send_xla_encode_device)
 
 
 # This function evaluates only the shapes during AST construction
@@ -170,5 +170,5 @@ mpi_send_p.def_effectful_abstract_eval(mpi_send_abstract_eval)
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_send_p, mpi_send_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_send_p, mpi_send_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_send_p, mpi_send_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_send_p, mpi_send_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/sendrecv.py
+++ b/mpi4jax/experimental/notoken/collective_ops/sendrecv.py
@@ -23,7 +23,7 @@ from mpi4jax._src.utils import (
 from mpi4jax._src.jax_compat import custom_call, token_type, ShapedArray
 from mpi4jax._src.decorators import (
     translation_rule_cpu,
-    translation_rule_gpu,
+    translation_rule_cuda,
     translation_rule_xpu,
 )
 from mpi4jax._src.validation import enforce_types
@@ -319,8 +319,8 @@ def mpi_sendrecv_xla_encode_xpu(
     )
 
 
-@translation_rule_gpu
-def mpi_sendrecv_xla_encode_gpu(
+@translation_rule_cuda
+def mpi_sendrecv_xla_encode_cuda(
     ctx,
     sendbuf,
     recvbuf,
@@ -469,5 +469,5 @@ ad.primitive_transposes[mpi_sendrecv_p] = mpi_sendrecv_transpose_rule
 
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_sendrecv_p, mpi_sendrecv_xla_encode_cpu, platform="cpu")
-mlir.register_lowering(mpi_sendrecv_p, mpi_sendrecv_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_sendrecv_p, mpi_sendrecv_xla_encode_cuda, platform="cuda")
 mlir.register_lowering(mpi_sendrecv_p, mpi_sendrecv_xla_encode_xpu, platform="xpu")

--- a/setup.py
+++ b/setup.py
@@ -335,8 +335,8 @@ def get_extensions():
 
         extensions.append(
             Extension(
-                name=f"{CYTHON_SUBMODULE_NAME}.mpi_xla_bridge_gpu",
-                sources=[f"{CYTHON_SUBMODULE_PATH}/mpi_xla_bridge_gpu.pyx"],
+                name=f"{CYTHON_SUBMODULE_NAME}.mpi_xla_bridge_cuda",
+                sources=[f"{CYTHON_SUBMODULE_PATH}/mpi_xla_bridge_cuda.pyx"],
                 include_dirs=cuda_info["compile"],
                 library_dirs=cuda_info["libdirs"],
                 libraries=cuda_info["libs"],

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -19,7 +19,7 @@ def test_ensure_cuda_ext(monkeypatch):
     from mpi4jax._src.decorators import ensure_cuda_ext
 
     with monkeypatch.context() as m:
-        m.setattr(xla_bridge, "HAS_GPU_EXT", False)
+        m.setattr(xla_bridge, "HAS_CUDA_EXT", False)
 
         with pytest.raises(ImportError) as excinfo:
             ensure_cuda_ext()

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -14,15 +14,15 @@ def test_envvar_parsing():
     assert not _is_falsy("foo")
 
 
-def test_ensure_gpu_ext(monkeypatch):
+def test_ensure_cuda_ext(monkeypatch):
     from mpi4jax._src import xla_bridge
-    from mpi4jax._src.decorators import ensure_gpu_ext
+    from mpi4jax._src.decorators import ensure_cuda_ext
 
     with monkeypatch.context() as m:
         m.setattr(xla_bridge, "HAS_GPU_EXT", False)
 
         with pytest.raises(ImportError) as excinfo:
-            ensure_gpu_ext()
+            ensure_cuda_ext()
 
         assert "GPU extensions could not be imported" in str(excinfo.value)
 


### PR DESCRIPTION
I want to resuscitate the HIP/AMD PR, and the _gpu naming was a bit confusing.
I think this makes sense in the long run...

This is essentially a series of 
 - search and repalces for `_gpu` to `_cuda`
 - rename the file `mpi_xla_bridge_gpu` to `mpi_xla_bridge_cuda`
 - rename `*_custom_call_targets` to `custom_call_targets` in the various `mpi_xla_bridge_*` 