### PR TITLE
Improve build errors when --no-build-isolation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,11 +102,14 @@ def get_cuda_paths_from_nvidia_pypi():
     # we need to get the site-packages of this install. to do so we use
     # mpi4py which must be installed
     mpi4py_spec = importlib.util.find_spec("mpi4py")
+
+    # This should never happen, because we already checked it can be imported
+    # But to be on the safe side, we throw this informative error.
     if mpi4py_spec is None:
         raise RuntimeError(
             "When building mpi4jax with --no-build-isolation"
             "you must install the dependencies, such as mpi4py and Cython,"
-            "yourself."
+            "yourself.\n\n"
             "Just run ``pip install cython mpi4py`` to fix this error."
         )
 

--- a/setup.py
+++ b/setup.py
@@ -303,9 +303,6 @@ def get_extensions():
         else:
             return []
 
-    sycl_info = get_sycl_info()
-    cuda_info = get_cuda_info()
-
     extensions = [
         Extension(
             name=f"{CYTHON_SUBMODULE_NAME}.{mod}",
@@ -314,6 +311,7 @@ def get_extensions():
         for mod in ("mpi_xla_bridge", "mpi_xla_bridge_cpu", "device_descriptors")
     ]
 
+    sycl_info = get_sycl_info()
     if sycl_info["compile"] and sycl_info["libdirs"]:
         extensions.append(
             Extension(
@@ -334,6 +332,7 @@ def get_extensions():
             "(XPU extensions will not be built)",
         )
 
+    cuda_info = get_cuda_info()
     if cuda_info["compile"] and cuda_info["libdirs"]:
         extra_extension_args = {}
         if len(cuda_info["rpaths"]) > 0:

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,14 @@ def get_cuda_paths_from_nvidia_pypi():
     # we need to get the site-packages of this install. to do so we use
     # mpi4py which must be installed
     mpi4py_spec = importlib.util.find_spec("mpi4py")
+    if mpi4py_spec is None:
+        raise RuntimeError(
+            "When building mpi4jax with --no-build-isolation"
+            "you must install the dependencies, such as mpi4py and Cython,"
+            "yourself."
+            "Just run ``pip install cython mpi4py`` to fix this error."
+        )
+
     depot_path = pathlib.Path(os.path.dirname(mpi4py_spec.origin)).parent
 
     # If the pip package nvidia-cuda-nvcc-cu11 is installed, it should have
@@ -194,9 +202,6 @@ def get_sycl_info():
     return sycl_info
 
 
-sycl_info = get_sycl_info()
-
-
 def find_files(bases, pattern):
     """Return list of files matching pattern in base folders and subfolders."""
     if isinstance(bases, (str, pathlib.Path)):
@@ -280,8 +285,6 @@ def get_cuda_info():
     return cuda_info
 
 
-cuda_info = get_cuda_info()
-
 # /end Cuda detection
 #####################
 
@@ -299,6 +302,9 @@ def get_extensions():
             raise RuntimeError("Building mpi4jax requires Cython and mpi4py")
         else:
             return []
+
+    sycl_info = get_sycl_info()
+    cuda_info = get_cuda_info()
 
     extensions = [
         Extension(


### PR DESCRIPTION
We were running `cuda_info()` and `sycl_info()` in the main module, before checking if mpi4py was installed in the `get_extensions()`.

This means that if `mpi4py` is not installed already, it gave import errors.

This fixes it.