### PR TITLE
Louder warning if mpi4py/Cython not installed in non isolated builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,17 @@ __pycache__/
 *.cpp
 *.so
 
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+
 # Distribution / packaging
 .Python
 build/

--- a/setup.py
+++ b/setup.py
@@ -302,6 +302,11 @@ def get_extensions():
         # this should only happen when using python setup.py
         # or pip install --no-build-isolation
         if require_extensions:
+            print_warning("mpi4py and/or Cython are not installed.",
+                "When using pip install --no-build-isolation or python setup.py, ",
+                "they MUST be installed BEFORE attempting to install mpi4jax.",
+                "",
+                "To fix this error, install mpi4py and Cython.")
             raise RuntimeError("Building mpi4jax requires Cython and mpi4py")
         else:
             return []

--- a/setup.py
+++ b/setup.py
@@ -302,11 +302,13 @@ def get_extensions():
         # this should only happen when using python setup.py
         # or pip install --no-build-isolation
         if require_extensions:
-            print_warning("mpi4py and/or Cython are not installed.",
+            print_warning(
+                "mpi4py and/or Cython are not installed.",
                 "When using pip install --no-build-isolation or python setup.py, ",
                 "they MUST be installed BEFORE attempting to install mpi4jax.",
                 "",
-                "To fix this error, install mpi4py and Cython.")
+                "To fix this error, install mpi4py and Cython.",
+            )
             raise RuntimeError("Building mpi4jax requires Cython and mpi4py")
         else:
             return []


### PR DESCRIPTION
More actionable and prominent warning.
The other one, people don't read.