### PR TITLE
Autodetect if we have MPI_GPU support

### DIFF
--- a/mpi4jax/_src/__init__.py
+++ b/mpi4jax/_src/__init__.py
@@ -32,5 +32,8 @@ from .collective_ops.sendrecv import sendrecv  # noqa: F401, E402
 
 from .utils import has_cuda_support, has_sycl_support  # noqa: F401, E402
 
+# import GPU
+from .mpi_direct_gpu import is_gpu_aware_mpi
+
 # sanitize namespace
 del jax_compat, xla_bridge, MPI, atexit, flush

--- a/mpi4jax/_src/mpi_direct_support_checker/mpi_gpu_aware.cc
+++ b/mpi4jax/_src/mpi_direct_support_checker/mpi_gpu_aware.cc
@@ -1,0 +1,138 @@
+#include <cstdlib>
+
+#include "mpi_gpu_aware.h"
+
+namespace detail {
+
+    static inline int
+    EnsureMPIIsInitialized() {
+        int is_mpi_initialized = 0;
+
+        if((::MPI_Initialized(&is_mpi_initialized) != MPI_SUCCESS) ||
+        (is_mpi_initialized == 0)) {
+            return -1;
+        }
+
+        // At this point MPI should be initialized. Except if an other thread
+        // called MPI_Finalize() in between.
+
+        return 0;
+    }
+
+#if defined(MPI_GPU_AWARE_CRAYMPICH_API_SUPPORT)
+    static inline int
+    getenv() {
+        const char* environment_string = std::getenv("MPICH_GPU_SUPPORT_ENABLED");
+        if(environment_string == NULL) {
+            return -1;
+        }
+
+        if(environment_string[0] != '1') {
+            return -1;
+        }
+
+        return 0;
+    }
+
+    /// Rely on MPIX_GPU_query_support. It requires that we have
+    /// MPIX_GPU_SUPPORT_CUDA defined to plug into the MPIX_GPU_query_support.
+    /// https://www.mpich.org/static/docs/v4.0.x/www3/MPIX_GPU_query_support.html
+    ///
+    static inline int
+    MPIx() {
+        int result = 0;
+
+        const auto CheckGPUKindSupport = [](int offset, int gpu_kind) -> int {
+            int is_gpu_kind_supported = 0;
+
+            if(::MPIX_GPU_query_support(gpu_kind, &is_gpu_kind_supported) != MPI_SUCCESS) {
+                return -1;
+            }
+
+            return is_gpu_kind_supported << offset;
+        };
+
+    #if defined(MPIX_GPU_SUPPORT_CUDA)
+        result |= CheckGPUKindSupport(0, MPIX_GPU_SUPPORT_CUDA);
+    #endif
+
+    #if defined(MPIX_GPU_SUPPORT_ZE)
+        result |= CheckGPUKindSupport(1, MPIX_GPU_SUPPORT_ZE);
+    #endif
+
+    #if defined(MPIX_GPU_SUPPORT_HIP)
+        result |= CheckGPUKindSupport(2, MPIX_GPU_SUPPORT_HIP);
+    #endif
+        return result == 0 ? -1 : result;
+    }
+
+    static inline int
+    DoCheck() {
+        if(getenv() < 0) {
+            return -1;
+        }
+
+        if(EnsureMPIIsInitialized() < 0) {
+            return -1;
+        }
+
+        if(MPIx() < 0) {
+            return -1;
+        }
+
+        return 0;
+    }
+
+#elif defined(MPI_GPU_AWARE_OPENMPI_API_SUPPORT)
+    static inline int
+    MPIx() {
+        int result = 0;
+
+    #if defined(MPI_GPU_AWARE_OPENMPI_API_SUPPORT) && defined(OMPI_HAVE_MPI_EXT_CUDA)
+        if(::MPIX_Query_cuda_support() != 1) {
+            return -1;
+        }
+        result |= 1 << 0;
+    #endif
+
+        // #if defined(MPI_GPU_AWARE_OPENMPI_API_SUPPORT) && defined(OMPI_HAVE_MPI_EXT_ZERO)
+        //         if(::MPIX_Query_zero_support() != 1) {
+        //             return -1;
+        //         }
+        //         result |= 1 << 2;
+        // #endif
+
+    #if defined(MPI_GPU_AWARE_OPENMPI_API_SUPPORT) && defined(OMPI_HAVE_MPI_EXT_ROCM)
+        if(::MPIX_Query_rocm_support() != 1) {
+            return -1;
+        }
+        result |= 1 << 2;
+    #endif
+
+        return result == 0 ? -1 : result;
+    }
+
+    static inline int
+    DoCheck() {
+        if(EnsureMPIIsInitialized() < 0) {
+            return -1;
+        }
+
+        if(MPIx() < 0) {
+            return -1;
+        }
+
+        return 0;
+    }
+#elif !defined(MPI_GPU_AWARE_API_SUPPORT)
+    static inline int
+    DoCheck() {
+        return -1;
+    }
+#endif
+} // namespace detail
+
+extern "C" int mpi_gpu_aware(void) {
+    static const int result = detail::DoCheck();
+    return result;
+}

--- a/mpi4jax/_src/mpi_direct_support_checker/mpi_gpu_aware.h
+++ b/mpi4jax/_src/mpi_direct_support_checker/mpi_gpu_aware.h
@@ -1,0 +1,52 @@
+#ifndef MPI_GPU_AWARE_H
+#define MPI_GPU_AWARE_H
+
+#include <mpi.h>
+
+#if defined(CRAY_MPICH_VERSION) && defined(MPIX_GPU_SUPPORT_CUDA)
+    #define MPI_GPU_AWARE_CRAYMPICH_API_SUPPORT       1
+    #define MPI_GPU_AWARE_CRAYMPICH_POTENTIAL_SUPPORT 1
+
+#elif defined(OPEN_MPI)
+
+    #include <mpi-ext.h>
+
+    #if(defined(OMPI_HAVE_MPI_EXT_ROCM) && OMPI_HAVE_MPI_EXT_ROCM) || \
+        (defined(OMPI_HAVE_MPI_EXT_CUDA) && OMPI_HAVE_MPI_EXT_CUDA)
+
+        #define MPI_GPU_AWARE_OPENMPI_API_SUPPORT 1
+
+        #if defined(MPIX_CUDA_AWARE_SUPPORT) && MPIX_CUDA_AWARE_SUPPORT
+            #define MPI_GPU_AWARE_OPENMPI_POTENTIAL_SUPPORT 1
+        #endif
+    #endif
+#endif
+
+#if defined(MPI_GPU_AWARE_CRAYMPICH_API_SUPPORT) || \
+    defined(MPI_GPU_AWARE_OPENMPI_API_SUPPORT)
+
+    /// The MPI implementation supports a runtime API we can use to ensure GPU
+    /// awareness.
+    ///
+    #define MPI_GPU_AWARE_API_SUPPORT 1
+#endif
+
+#if defined(MPI_GPU_AWARE_CRAYMPICH_POTENTIAL_SUPPORT) || \
+    defined(MPI_GPU_AWARE_OPENMPI_POTENTIAL_SUPPORT)
+
+    /// We assume it is likely that the MPI implementation is GPU aware ?
+    ///
+    #define MPI_GPU_AWARE_POTENTIAL_SUPPORT 1
+#endif
+
+/// GPU aware MPI is a runtime decision on Cray MPICH. It relies on a library
+/// called GPU Transport Layer (GTL). This library is linked by the wrapper when
+/// a GPU architecture module is loaded (i.e.: craype-x86-trento).
+/// It is not possible to determine at compile time if the MPI implementation
+/// will be GPU aware. We can know if the MPI could have that feature enabled,
+/// but not if it will be enabled.
+/// Returns: < 0 if we could not determine if the MPI is GPU aware.
+///
+extern "C" int mpi_gpu_aware(void);
+
+#endif

--- a/mpi4jax/_src/mpi_direct_support_checker/mpi_gpu_aware_checker.pyx
+++ b/mpi4jax/_src/mpi_direct_support_checker/mpi_gpu_aware_checker.pyx
@@ -1,0 +1,6 @@
+# mpi_check.pyx
+cdef extern from "mpi_gpu_aware.h":
+    int mpi_gpu_aware()
+
+def is_gpu_aware_mpi():
+    return mpi_gpu_aware()

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,9 @@ DEV_DEPENDENCIES = [
 CYTHON_SUBMODULE_NAME = "mpi4jax._src.xla_bridge"
 CYTHON_SUBMODULE_PATH = "mpi4jax/_src/xla_bridge"
 
+CYTHON_DIRECTGPU_SUBMODULE_NAME = "mpi4jax._src.mpi_direct_gpu"
+CYTHON_DIRECTGPU_SUBMODULE_PATH = "mpi4jax/_src/mpi_direct_support_checker"
+
 
 #######
 # Utils
@@ -313,6 +316,16 @@ def get_extensions():
         )
         for mod in ("mpi_xla_bridge", "mpi_xla_bridge_cpu", "device_descriptors")
     ]
+
+    extensions.append(
+        Extension(
+        f"{CYTHON_DIRECTGPU_SUBMODULE_NAME}",
+        sources=[f"{CYTHON_DIRECTGPU_SUBMODULE_PATH}/mpi_gpu_aware_checker.pyx", 
+                 f"{CYTHON_DIRECTGPU_SUBMODULE_PATH}/mpi_gpu_aware.cc"],
+        language="c++",
+        #libraries=["mpi"],  # Link against the MPI library
+    ))
+
 
     sycl_info = get_sycl_info()
     if sycl_info["compile"] and sycl_info["libdirs"]:


### PR DESCRIPTION
I don't want to make the switch automatic, but giving a more informative message to the user whether we detect it enabled or not might be useful for debugging configurations (for example, I recently needed it for debugging some issues)...

The scripts are taken from https://dci.dci-gitlab.cines.fr/webextranet/software_stack/libraries/index.html#detecting-if-mpi-is-gpu-aware