### PR TITLE
Fix default no token mode for older JAX versions

### DIFF
--- a/mpi4jax/_src/utils.py
+++ b/mpi4jax/_src/utils.py
@@ -7,11 +7,13 @@ from mpi4py import MPI as _MPI
 
 import numpy as _np
 
+import jax
+
 from jax.interpreters import xla, mlir
 import jaxlib.mlir.ir as ir
 from jaxlib.mlir.dialects import mhlo
 
-from .jax_compat import token_type, register_effect, EffectType
+from .jax_compat import token_type, register_effect, EffectType, versiontuple
 
 
 class MPIEffect(EffectType):
@@ -176,12 +178,31 @@ def has_sycl_support() -> bool:
 
 def prefer_notoken() -> bool:
     """Returns True if primitive implementations should prefer not to use tokens."""
-    use_notoken = os.environ.get("MPI4JAX_PREFER_NOTOKEN", "1").lower() in (
-        "1",
-        "true",
-        "on",
-    )
-    if not use_notoken:
+
+    # No-token mode only works with JAX >= 0.5.1. See:
+    # - https://github.com/mpi4jax/mpi4jax/issues/274
+    # - https://github.com/jax-ml/jax/issues/26087
+    jax_ver_sufficient = versiontuple(jax.__version__) >= (0, 5, 1)
+    env_var = os.environ.get("MPI4JAX_PREFER_NOTOKEN")
+
+    if env_var is None:
+        use_notoken = jax_ver_sufficient
+    else:
+        use_notoken = env_var.lower() in ("1", "true", "on")
+
+    if use_notoken is False and env_var is None:
+        warnings.warn(
+            "Defaulting to the deprecated token mode. "
+            "No-token mode fully works only for JAX version >= 0.5.1 but you have {jax.__version__}."
+            "You can set the environment variable `MPI4JAX_PREFER_NOTOKEN=0` to silence this warning."
+        )
+
+    if use_notoken and not jax_ver_sufficient:
+        warnings.warn(
+            f"No-token mode fully works only for JAX version >= 0.5.1 but you have {jax.__version__}."
+        )
+
+    if not use_notoken and jax_ver_sufficient:
         warnings.warn(
             "Token mode is deprecated and may be incompatible with recent JAX versions. "
             "Consider setting the environment variable MPI4JAX_PREFER_NOTOKEN=1 to suppress this warning."

--- a/tests/test_prefer_notoken.py
+++ b/tests/test_prefer_notoken.py
@@ -1,0 +1,51 @@
+import pytest
+
+import warnings
+
+
+def test_prefer_notoken(monkeypatch):
+    import mpi4jax
+    import jax
+
+    # If JAX < 0.5.1 we default to token mode if we not enforce it
+    jax_ver = "0.5.0"
+    with monkeypatch.context() as m:
+        m.setattr(jax, "__version__", jax_ver)
+        m.delenv("MPI4JAX_PREFER_NOTOKEN", raising=False)
+        with pytest.warns(UserWarning):
+            assert mpi4jax._src.utils.prefer_notoken() is False
+
+    with monkeypatch.context() as m:
+        m.setattr(jax, "__version__", jax_ver)
+        m.setenv("MPI4JAX_PREFER_NOTOKEN", "0")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            assert mpi4jax._src.utils.prefer_notoken() is False
+
+    with monkeypatch.context() as m:
+        m.setattr(jax, "__version__", jax_ver)
+        m.setenv("MPI4JAX_PREFER_NOTOKEN", "1")
+        with pytest.warns(UserWarning):
+            assert mpi4jax._src.utils.prefer_notoken() is True
+
+    # Default to no token mode, if we not enforce it
+    jax_ver = "0.5.1"
+    with monkeypatch.context() as m:
+        m.setattr(jax, "__version__", jax_ver)
+        m.delenv("MPI4JAX_PREFER_NOTOKEN", raising=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            assert mpi4jax._src.utils.prefer_notoken() is True
+
+    with monkeypatch.context() as m:
+        m.setattr(jax, "__version__", jax_ver)
+        m.setenv("MPI4JAX_PREFER_NOTOKEN", "0")
+        with pytest.warns(UserWarning):
+            assert mpi4jax._src.utils.prefer_notoken() is False
+
+    with monkeypatch.context() as m:
+        m.setattr(jax, "__version__", jax_ver)
+        m.setenv("MPI4JAX_PREFER_NOTOKEN", "1")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            assert mpi4jax._src.utils.prefer_notoken() is True


### PR DESCRIPTION
If JAX < 0.5.1, the default no token mode does not work. See issue #274 and:
  - https://github.com/mpi4jax/mpi4jax/issues/274
  - https://github.com/jax-ml/jax/issues/26087

This commit sets that if JAX < 0.5.1, it switches to token mode. However, if the user sets "MPI4JAX_PREFER_NOTOKEN=1" it keeps it becuase, AFAIK, the problem is only limited to JAX linear algebra. 